### PR TITLE
Prepare Release Collector for production deployment

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -47,9 +47,9 @@ on:
         type: boolean
         default: false
 
-  # schedule:
-    # Weekly run on Mondays at 04:35 UTC
-    # - cron: '35 4 * * 1'
+  schedule:
+    # Daily run at 04:35 UTC (for testing)
+    - cron: '35 4 * * *'
 
 env:
   # GitHub API Configuration
@@ -499,6 +499,11 @@ jobs:
         with:
           name: release-reports-${{ github.run_number }}
           path: staging
+
+      - name: Copy staging entry page
+        run: |
+          cp workflows/release-collector/staging-index.html staging/viewers/index.html
+          echo "✓ Copied staging-index.html to viewers/index.html"
 
       - name: Show deployment contents
         run: |

--- a/workflows/release-collector/production-index.html
+++ b/workflows/release-collector/production-index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>CAMARA Release Viewers</title>
+  <meta name="description" content="Interactive viewers for CAMARA API releases">
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; }
+    .viewer-link { display: block; padding: 12px; margin: 8px 0; border: 1px solid #ddd;
+                   border-radius: 4px; text-decoration: none; color: #0969da; }
+    .viewer-link:hover { background: #f6f8fa; }
+  </style>
+</head>
+<body>
+  <h1>CAMARA Release Viewers</h1>
+  <p>Interactive release tracking for CAMARA APIs</p>
+
+  <h2>Meta-Release Viewers</h2>
+  <a href="fall25.html" class="viewer-link">Fall 2025</a>
+  <a href="spring25.html" class="viewer-link">Spring 2025</a>
+  <a href="fall24.html" class="viewer-link">Fall 2024</a>
+
+  <h2>Portfolio Overview</h2>
+  <a href="portfolio.html" class="viewer-link">Complete API Portfolio</a>
+
+  <footer>
+    <p><a href="https://github.com/camaraproject/project-administration">Source</a> |
+       <a href="https://github.com/camaraproject/project-administration/issues">Report Issues</a></p>
+  </footer>
+</body>
+</html>

--- a/workflows/release-collector/staging-index.html
+++ b/workflows/release-collector/staging-index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>CAMARA Release Viewers - Staging</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; }
+    .notice { background: #fff3cd; border: 1px solid #ffc107; padding: 16px; margin-bottom: 24px;
+              border-radius: 4px; }
+    .viewer-link { display: block; padding: 12px; margin: 8px 0; border: 1px solid #ddd;
+                   border-radius: 4px; text-decoration: none; color: #0969da; }
+    .viewer-link:hover { background: #f6f8fa; }
+    .production-link { background: #d1ecf1; border-color: #0c5460; color: #0c5460; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <div class="notice">
+    ⚠️ <strong>Staging Environment</strong> - These viewers are for review only.<br>
+    For production use, visit:
+    <a href="https://camaraproject.github.io/releases/">camaraproject.github.io/releases/</a>
+  </div>
+
+  <h1>CAMARA Release Viewers - Staging</h1>
+
+  <h2>Production Viewers</h2>
+  <a href="https://camaraproject.github.io/releases/" class="viewer-link production-link">
+    → Go to Production Viewers
+  </a>
+
+  <h2>Staging Viewers (Preview)</h2>
+  <p>Review these before production deployment</p>
+  <a href="fall25.html" class="viewer-link">Fall 2025 (Staging)</a>
+  <a href="spring25.html" class="viewer-link">Spring 2025 (Staging)</a>
+  <a href="fall24.html" class="viewer-link">Fall 2024 (Staging)</a>
+  <a href="portfolio.html" class="viewer-link">Portfolio (Staging)</a>
+  <a href="internal.html" class="viewer-link">Internal Admin View (Staging Only)</a>
+
+  <footer>
+    <p><a href="https://github.com/camaraproject/project-administration">Source</a> |
+       <a href="https://github.com/camaraproject/project-administration/issues">Report Issues</a></p>
+  </footer>
+</body>
+</html>

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CAMARA API Portfolio Overview (Alpha)</title>
+  <title>CAMARA API Portfolio Overview</title>
   <style>
     {{VIEWER_STYLES}}
 
@@ -283,7 +283,7 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>CAMARA API Portfolio Overview (Alpha)</h1>
+      <h1>CAMARA API Portfolio Overview</h1>
       <div class="header-content">
         <div class="metadata" id="header-metadata"></div>
       </div>


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Prepares the Release Collector workflow for production deployment to camaraproject.github.io/releases/:

- Adds static entry pages for production and staging environments
- Removes Alpha label from portfolio viewer (now production-ready)
- Enables daily scheduled runs for testing incremental behavior
- Configures staging deployment to include entry page (index.html)

This PR implements the workflow preparation tasks required before production deployment can proceed.

#### Which issue(s) this PR fixes:

Fixes #75

#### Special notes for reviewers:

**Schedule changed to daily**: The cron schedule is set to daily (`35 4 * * *`) for testing purposes. This allows more frequent runs to validate incremental behavior before switching to weekly schedule in production.

**New files**: Two static HTML entry pages are added:
- `production-index.html`: Clean entry page for production deployment
- `staging-index.html`: Entry page with staging warning and production links

**Staging deployment**: The workflow now copies `staging-index.html` to `viewers/index.html` during staging deployment, so reviewers can preview the entry page at `https://camaraproject.github.io/project-administration/index.html`

**Next steps**: After merge, monitor scheduled runs for 1-2 weeks to validate incremental behavior, then proceed with production deployment workflow (issue #76).

#### Changelog input

```release-note
Add production and staging entry pages for Release Collector viewers. Remove Alpha label from portfolio viewer. Enable daily scheduled runs for testing.
```

#### Additional documentation

```docs

```