### PR TITLE
feat: Extend release collector with pre-releases and repository tracking

### DIFF
--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -6,7 +6,7 @@
 # Safety checks:
 # - Default mode: Compares staging vs main timestamps to prevent deploying stale content
 # - Rollback mode: Allows deploying specific ref from main branch history
-# - Emergency mode: Allows deploying from any branch (explicit override)
+# - Emergency or test mode: Allows deploying from any branch (explicit override)
 #
 # PREREQUISITES:
 # - Secret PRODUCTION_DEPLOY_TOKEN: Fine-grained PAT for camaraproject/camaraproject.github.io
@@ -49,7 +49,7 @@ on:
         default: ''
         type: string
       allow_branch:
-        description: 'Allow deployment from any branch (emergency override). Uses current branch when ref is empty. Skips timestamp safety check.'
+        description: 'Emergency or test: deploy from current branch instead of main. Uses current branch when ref is empty. Skips timestamp safety check.'
         required: false
         type: boolean
         default: false
@@ -95,7 +95,7 @@ jobs:
           CURRENT_BRANCH="${{ github.ref_name }}"
 
           if [[ "$ALLOW_BRANCH" == "true" ]]; then
-            # Emergency mode: Any ref allowed, use current branch if ref is empty
+            # Emergency or test mode: Any ref allowed, use current branch if ref is empty
             if [[ -z "$INPUT_REF" ]]; then
               DEPLOY_REF="$CURRENT_BRANCH"
             else
@@ -104,7 +104,7 @@ jobs:
             echo "mode=emergency" >> $GITHUB_OUTPUT
             echo "ref=$DEPLOY_REF" >> $GITHUB_OUTPUT
             echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-            echo "::warning::EMERGENCY MODE - Deploying from $DEPLOY_REF without safety checks"
+            echo "::warning::EMERGENCY OR TEST MODE - Deploying from $DEPLOY_REF without safety checks"
 
           elif [[ -z "$INPUT_REF" ]]; then
             # Default mode: HEAD of main
@@ -204,7 +204,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [[ "${{ steps.determine-ref.outputs.mode }}" == "emergency" ]]; then
-            echo "> **Warning**: Emergency mode - deploying without timestamp safety check" >> $GITHUB_STEP_SUMMARY
+            echo "> **Warning**: Emergency or test mode - deploying without timestamp safety check" >> $GITHUB_STEP_SUMMARY
           fi
 
   # =========================================================================================
@@ -704,7 +704,7 @@ jobs:
 
           # Mode warning (rollback and emergency skip timestamp checks)
           if [[ "$DEPLOY_MODE" == "emergency" ]]; then
-            echo "> **Warning**: EMERGENCY MODE - deploying from non-main branch. Timestamp safety check was bypassed." >> $GITHUB_STEP_SUMMARY
+            echo "> **Warning**: EMERGENCY OR TEST MODE - deploying from non-main branch. Timestamp safety check was bypassed." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           elif [[ "$DEPLOY_MODE" == "rollback" ]]; then
             echo "> **Note**: ROLLBACK MODE - deploying specific ref from main. Timestamp safety check was bypassed." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -28,6 +28,21 @@ name: Release Collector - Production Deploy
 on:
   workflow_dispatch:
     inputs:
+      deploy_viewers:
+        description: 'Deploy viewers to production site'
+        required: false
+        type: boolean
+        default: true
+      upload_metadata:
+        description: 'Upload release-metadata files to GitHub releases'
+        required: false
+        type: boolean
+        default: true
+      upload_releases:
+        description: 'Selective upload: comma-separated list (e.g., "QualityOnDemand/r1.2,DeviceLocation/r2.1"). Empty = all.'
+        required: false
+        type: string
+        default: ''
       ref:
         description: 'ROLLBACK ONLY: Git ref from main to deploy. Leave empty for normal deployment (with timestamp safety check).'
         required: false
@@ -193,7 +208,9 @@ jobs:
   generate-viewers:
     name: Generate Viewers
     needs: validate-deployment
-    if: needs.validate-deployment.outputs.skip_deploy != 'true'
+    if: |
+      needs.validate-deployment.outputs.skip_deploy != 'true' &&
+      (github.event.inputs.deploy_viewers || 'true') == 'true'
     runs-on: ubuntu-latest
     outputs:
       viewers_generated: ${{ steps.generate.outputs.success }}
@@ -267,7 +284,9 @@ jobs:
   deploy-production:
     name: Deploy to Production
     needs: [validate-deployment, generate-viewers]
-    if: github.event.inputs.dry_run != 'true'
+    if: |
+      github.event.inputs.dry_run != 'true' &&
+      needs.generate-viewers.result == 'success'
     runs-on: ubuntu-latest
     outputs:
       deployed: ${{ steps.push.outputs.deployed }}
@@ -357,11 +376,136 @@ jobs:
           echo "Pages deployment triggered successfully"
 
   # =========================================================================================
-  # Job 4: Workflow Summary
+  # Job 4: Upload Release Metadata to GitHub Releases
+  # =========================================================================================
+  upload-release-metadata:
+    name: Upload to GitHub Releases
+    needs: validate-deployment
+    if: |
+      needs.validate-deployment.outputs.skip_deploy != 'true' &&
+      (github.event.inputs.upload_metadata || 'true') == 'true' &&
+      github.event.inputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      uploaded_count: ${{ steps.upload.outputs.uploaded }}
+      failed_count: ${{ steps.upload.outputs.failed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-deployment.outputs.deploy_ref }}
+
+      - name: Check for release artifacts
+        id: check
+        run: |
+          if [[ -d "data/release-artifacts" ]]; then
+            COUNT=$(find data/release-artifacts -name "release-metadata.yaml" | wc -l | tr -d ' ')
+            echo "Found $COUNT release metadata files to upload"
+            echo "has_artifacts=true" >> $GITHUB_OUTPUT
+            echo "count=$COUNT" >> $GITHUB_OUTPUT
+          else
+            echo "No release artifacts found in data/release-artifacts/"
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
+            echo "count=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload metadata files to GitHub releases
+        id: upload
+        if: steps.check.outputs.has_artifacts == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PRODUCTION_DEPLOY_TOKEN }}
+          UPLOAD_RELEASES: ${{ github.event.inputs.upload_releases }}
+        run: |
+          UPLOADED=0
+          FAILED=0
+          SKIPPED=0
+
+          # Parse selective list if provided
+          if [[ -n "$UPLOAD_RELEASES" ]]; then
+            echo "Selective upload mode: $UPLOAD_RELEASES"
+            echo ""
+
+            IFS=',' read -ra RELEASES <<< "$UPLOAD_RELEASES"
+            for release in "${RELEASES[@]}"; do
+              release=$(echo "$release" | xargs)  # trim whitespace
+              repo="${release%/*}"
+              tag="${release#*/}"
+
+              YAML_FILE="data/release-artifacts/$repo/$tag/release-metadata.yaml"
+              JSON_FILE="data/release-artifacts/$repo/$tag/release-metadata.json"
+
+              if [[ ! -f "$YAML_FILE" ]] || [[ ! -f "$JSON_FILE" ]]; then
+                echo "⚠️ Files not found for $repo/$tag"
+                FAILED=$((FAILED + 1))
+                continue
+              fi
+
+              echo "Uploading $repo/$tag..."
+
+              if gh release upload "$tag" --repo "camaraproject/$repo" \
+                  "$YAML_FILE" "$JSON_FILE" --clobber 2>/dev/null; then
+                echo "  ✓ Uploaded"
+                UPLOADED=$((UPLOADED + 1))
+              else
+                echo "  ✗ Failed (release may not exist or no permission)"
+                FAILED=$((FAILED + 1))
+              fi
+            done
+
+          else
+            # Full upload mode
+            echo "Full upload mode: all releases"
+            echo ""
+
+            for repo_dir in data/release-artifacts/*/; do
+              repo=$(basename "$repo_dir")
+
+              for tag_dir in "$repo_dir"*/; do
+                tag=$(basename "$tag_dir")
+
+                YAML_FILE="$tag_dir/release-metadata.yaml"
+                JSON_FILE="$tag_dir/release-metadata.json"
+
+                if [[ ! -f "$YAML_FILE" ]] || [[ ! -f "$JSON_FILE" ]]; then
+                  echo "⚠️ Missing files in $repo/$tag"
+                  SKIPPED=$((SKIPPED + 1))
+                  continue
+                fi
+
+                echo "Uploading $repo/$tag..."
+
+                if gh release upload "$tag" --repo "camaraproject/$repo" \
+                    "$YAML_FILE" "$JSON_FILE" --clobber 2>/dev/null; then
+                  echo "  ✓ Uploaded"
+                  UPLOADED=$((UPLOADED + 1))
+                else
+                  echo "  ✗ Failed (release may not exist or no permission)"
+                  FAILED=$((FAILED + 1))
+                fi
+              done
+            done
+          fi
+
+          echo ""
+          echo "=== Upload Summary ==="
+          echo "Uploaded: $UPLOADED"
+          echo "Failed: $FAILED"
+          echo "Skipped: $SKIPPED"
+
+          echo "uploaded=$UPLOADED" >> $GITHUB_OUTPUT
+          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+
+          if [[ $FAILED -gt 0 ]]; then
+            echo "::warning::Some uploads failed. Check logs for details."
+          fi
+
+  # =========================================================================================
+  # Job 5: Workflow Summary
   # =========================================================================================
   summary:
     name: Workflow Summary
-    needs: [validate-deployment, generate-viewers, deploy-production]
+    needs: [validate-deployment, generate-viewers, deploy-production, upload-release-metadata]
     if: always()
     runs-on: ubuntu-latest
 
@@ -378,6 +522,9 @@ jobs:
           VALIDATION_RESULT="${{ needs.validate-deployment.result }}"
           DEPLOYED="${{ needs.deploy-production.outputs.deployed }}"
           COMMIT_URL="${{ needs.deploy-production.outputs.commit_url }}"
+          UPLOAD_RESULT="${{ needs.upload-release-metadata.result }}"
+          UPLOADED_COUNT="${{ needs.upload-release-metadata.outputs.uploaded_count }}"
+          FAILED_COUNT="${{ needs.upload-release-metadata.outputs.failed_count }}"
 
           # Determine if validation failed (job failed or skip_deploy set)
           VALIDATION_FAILED="false"
@@ -442,6 +589,22 @@ jobs:
             echo "| spring25.html | Spring 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
             echo "| fall25.html | Fall 2025 meta-release viewer |" >> $GITHUB_STEP_SUMMARY
             echo "| portfolio.html | Portfolio overview |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Metadata upload results
+          if [[ "$UPLOAD_RESULT" == "success" && -n "$UPLOADED_COUNT" ]]; then
+            echo "### Release Metadata Upload" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- Uploaded: $UPLOADED_COUNT releases" >> $GITHUB_STEP_SUMMARY
+            if [[ "$FAILED_COUNT" -gt 0 ]]; then
+              echo "- Failed: $FAILED_COUNT releases (check logs)" >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "" >> $GITHUB_STEP_SUMMARY
+          elif [[ "$UPLOAD_RESULT" == "skipped" ]]; then
+            echo "### Release Metadata Upload" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Skipped (upload_metadata=false or no artifacts)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/.github/workflows/release-collector-production.yml
+++ b/.github/workflows/release-collector-production.yml
@@ -49,7 +49,7 @@ on:
         default: ''
         type: string
       allow_branch:
-        description: 'Allow deployment from any branch (emergency override). Skips also timestamp safety check.'
+        description: 'Allow deployment from any branch (emergency override). Uses current branch when ref is empty. Skips timestamp safety check.'
         required: false
         type: boolean
         default: false
@@ -83,7 +83,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref || 'main' }}
+          # Use ref if provided, else current branch if allow_branch, else main
+          ref: ${{ github.event.inputs.ref || (github.event.inputs.allow_branch == 'true' && github.ref_name) || 'main' }}
           fetch-depth: 0  # Full history for ancestor check
 
       - name: Determine deployment ref and mode
@@ -91,8 +92,21 @@ jobs:
         run: |
           INPUT_REF="${{ github.event.inputs.ref }}"
           ALLOW_BRANCH="${{ github.event.inputs.allow_branch }}"
+          CURRENT_BRANCH="${{ github.ref_name }}"
 
-          if [[ -z "$INPUT_REF" ]]; then
+          if [[ "$ALLOW_BRANCH" == "true" ]]; then
+            # Emergency mode: Any ref allowed, use current branch if ref is empty
+            if [[ -z "$INPUT_REF" ]]; then
+              DEPLOY_REF="$CURRENT_BRANCH"
+            else
+              DEPLOY_REF="$INPUT_REF"
+            fi
+            echo "mode=emergency" >> $GITHUB_OUTPUT
+            echo "ref=$DEPLOY_REF" >> $GITHUB_OUTPUT
+            echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+            echo "::warning::EMERGENCY MODE - Deploying from $DEPLOY_REF without safety checks"
+
+          elif [[ -z "$INPUT_REF" ]]; then
             # Default mode: HEAD of main
             DEPLOY_REF="main"
             DEPLOY_MODE="default"
@@ -100,15 +114,6 @@ jobs:
             echo "ref=main" >> $GITHUB_OUTPUT
             echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
             echo "Using default mode: HEAD of main"
-
-          elif [[ "$ALLOW_BRANCH" == "true" ]]; then
-            # Emergency mode: Any ref allowed
-            DEPLOY_REF="$INPUT_REF"
-            DEPLOY_MODE="emergency"
-            echo "mode=emergency" >> $GITHUB_OUTPUT
-            echo "ref=$INPUT_REF" >> $GITHUB_OUTPUT
-            echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-            echo "::warning::EMERGENCY MODE - Deploying from $INPUT_REF without safety checks"
 
           else
             # Rollback mode: Verify ref is on main
@@ -377,18 +382,22 @@ jobs:
 
   # =========================================================================================
   # Job 4: Upload Release Metadata to GitHub Releases
+  # Analyzes staged artifacts vs existing release assets, then uploads if not dry-run
   # =========================================================================================
   upload-release-metadata:
     name: Upload to GitHub Releases
     needs: validate-deployment
     if: |
       needs.validate-deployment.outputs.skip_deploy != 'true' &&
-      (github.event.inputs.upload_metadata || 'true') == 'true' &&
-      github.event.inputs.dry_run != 'true'
+      (github.event.inputs.upload_metadata || 'true') == 'true'
     runs-on: ubuntu-latest
     outputs:
-      uploaded_count: ${{ steps.upload.outputs.uploaded }}
-      failed_count: ${{ steps.upload.outputs.failed }}
+      new_count: ${{ steps.analyze.outputs.new }}
+      update_count: ${{ steps.analyze.outputs.update }}
+      current_count: ${{ steps.analyze.outputs.current }}
+      no_release_count: ${{ steps.analyze.outputs.no_release }}
+      uploaded_count: ${{ steps.analyze.outputs.uploaded }}
+      failed_count: ${{ steps.analyze.outputs.failed }}
 
     steps:
       - name: Checkout repository
@@ -401,7 +410,7 @@ jobs:
         run: |
           if [[ -d "data/release-artifacts" ]]; then
             COUNT=$(find data/release-artifacts -name "release-metadata.yaml" | wc -l | tr -d ' ')
-            echo "Found $COUNT release metadata files to upload"
+            echo "Found $COUNT release metadata files"
             echo "has_artifacts=true" >> $GITHUB_OUTPUT
             echo "count=$COUNT" >> $GITHUB_OUTPUT
           else
@@ -410,95 +419,247 @@ jobs:
             echo "count=0" >> $GITHUB_OUTPUT
           fi
 
-      - name: Upload metadata files to GitHub releases
-        id: upload
+      - name: Analyze and upload metadata files
+        id: analyze
         if: steps.check.outputs.has_artifacts == 'true'
         env:
           GH_TOKEN: ${{ secrets.PRODUCTION_DEPLOY_TOKEN }}
           UPLOAD_RELEASES: ${{ github.event.inputs.upload_releases }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
+          # Statistics
+          NEW=0
+          UPDATE=0
+          CURRENT=0
+          NO_RELEASE=0
           UPLOADED=0
           FAILED=0
-          SKIPPED=0
 
-          # Parse selective list if provided
+          # Report files
+          mkdir -p reports
+          REPORT_MD="reports/upload-report.md"
+          REPORT_JSONL="reports/upload-report.jsonl"
+          MODE="${DRY_RUN:-false}"
+          [[ "$MODE" == "true" ]] && MODE_LABEL="plan" || MODE_LABEL="apply"
+
+          # Initialize report
+          echo "# Release Metadata Upload Report" > "$REPORT_MD"
+          echo "" >> "$REPORT_MD"
+          echo "**Mode:** ${MODE_LABEL^^}" >> "$REPORT_MD"
+          echo "**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$REPORT_MD"
+          echo "" >> "$REPORT_MD"
+          > "$REPORT_JSONL"
+
+          # Arrays to collect results by category
+          declare -a NEW_LIST=()
+          declare -a UPDATE_LIST=()
+          declare -a CURRENT_LIST=()
+          declare -a NO_RELEASE_LIST=()
+          declare -a UPLOADED_LIST=()
+          declare -a FAILED_LIST=()
+
+          # Build release list
+          RELEASE_LIST=()
           if [[ -n "$UPLOAD_RELEASES" ]]; then
-            echo "Selective upload mode: $UPLOAD_RELEASES"
-            echo ""
-
+            echo "Selective mode: $UPLOAD_RELEASES"
             IFS=',' read -ra RELEASES <<< "$UPLOAD_RELEASES"
             for release in "${RELEASES[@]}"; do
-              release=$(echo "$release" | xargs)  # trim whitespace
-              repo="${release%/*}"
-              tag="${release#*/}"
-
-              YAML_FILE="data/release-artifacts/$repo/$tag/release-metadata.yaml"
-              JSON_FILE="data/release-artifacts/$repo/$tag/release-metadata.json"
-
-              if [[ ! -f "$YAML_FILE" ]] || [[ ! -f "$JSON_FILE" ]]; then
-                echo "⚠️ Files not found for $repo/$tag"
-                FAILED=$((FAILED + 1))
-                continue
-              fi
-
-              echo "Uploading $repo/$tag..."
-
-              if gh release upload "$tag" --repo "camaraproject/$repo" \
-                  "$YAML_FILE" "$JSON_FILE" --clobber 2>/dev/null; then
-                echo "  ✓ Uploaded"
-                UPLOADED=$((UPLOADED + 1))
-              else
-                echo "  ✗ Failed (release may not exist or no permission)"
-                FAILED=$((FAILED + 1))
-              fi
+              release=$(echo "$release" | xargs)
+              RELEASE_LIST+=("$release")
             done
-
           else
-            # Full upload mode
-            echo "Full upload mode: all releases"
-            echo ""
-
+            echo "Full mode: all releases"
             for repo_dir in data/release-artifacts/*/; do
               repo=$(basename "$repo_dir")
-
               for tag_dir in "$repo_dir"*/; do
                 tag=$(basename "$tag_dir")
-
-                YAML_FILE="$tag_dir/release-metadata.yaml"
-                JSON_FILE="$tag_dir/release-metadata.json"
-
-                if [[ ! -f "$YAML_FILE" ]] || [[ ! -f "$JSON_FILE" ]]; then
-                  echo "⚠️ Missing files in $repo/$tag"
-                  SKIPPED=$((SKIPPED + 1))
-                  continue
-                fi
-
-                echo "Uploading $repo/$tag..."
-
-                if gh release upload "$tag" --repo "camaraproject/$repo" \
-                    "$YAML_FILE" "$JSON_FILE" --clobber 2>/dev/null; then
-                  echo "  ✓ Uploaded"
-                  UPLOADED=$((UPLOADED + 1))
-                else
-                  echo "  ✗ Failed (release may not exist or no permission)"
-                  FAILED=$((FAILED + 1))
-                fi
+                RELEASE_LIST+=("$repo/$tag")
               done
             done
           fi
 
+          echo "Analyzing ${#RELEASE_LIST[@]} releases..."
           echo ""
-          echo "=== Upload Summary ==="
-          echo "Uploaded: $UPLOADED"
-          echo "Failed: $FAILED"
-          echo "Skipped: $SKIPPED"
 
+          # Process each release
+          for release in "${RELEASE_LIST[@]}"; do
+            repo="${release%/*}"
+            tag="${release#*/}"
+
+            YAML_FILE="data/release-artifacts/$repo/$tag/release-metadata.yaml"
+            JSON_FILE="data/release-artifacts/$repo/$tag/release-metadata.json"
+
+            # Check local files exist
+            if [[ ! -f "$YAML_FILE" ]] || [[ ! -f "$JSON_FILE" ]]; then
+              echo "⚠️  $repo/$tag - local files missing"
+              echo "::warning::$repo/$tag - local files missing (not in release-artifacts)"
+              echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"missing_local\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+              continue
+            fi
+
+            # Check if release exists and get assets
+            ASSETS=$(gh release view "$tag" --repo "camaraproject/$repo" --json assets -q '.assets[].name' 2>/dev/null)
+            RELEASE_EXISTS=$?
+
+            if [[ $RELEASE_EXISTS -ne 0 ]]; then
+              # Release doesn't exist
+              echo "❌  $repo/$tag - no release"
+              NO_RELEASE=$((NO_RELEASE + 1))
+              NO_RELEASE_LIST+=("$repo|$tag")
+              echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"no_release\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+              continue
+            fi
+
+            # Check if our assets exist
+            HAS_YAML=$(echo "$ASSETS" | grep -c "release-metadata.yaml" || true)
+
+            if [[ "$HAS_YAML" -eq 0 ]]; then
+              # Assets don't exist - NEW
+              if [[ "$DRY_RUN" == "true" ]]; then
+                echo "🆕  $repo/$tag - new (would upload)"
+                NEW=$((NEW + 1))
+                NEW_LIST+=("$repo|$tag")
+                echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"new\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+              else
+                echo -n "🆕  $repo/$tag - new, uploading... "
+                UPLOAD_ERR=$(gh release upload "$tag" --repo "camaraproject/$repo" "$YAML_FILE" "$JSON_FILE" --clobber 2>&1) && UPLOAD_OK=true || UPLOAD_OK=false
+                if [[ "$UPLOAD_OK" == "true" ]]; then
+                  echo "✓"
+                  UPLOADED=$((UPLOADED + 1))
+                  UPLOADED_LIST+=("$repo|$tag|new")
+                  echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"uploaded\",\"action\":\"new\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+                else
+                  echo "✗"
+                  echo "    Error: $UPLOAD_ERR"
+                  FAILED=$((FAILED + 1))
+                  FAILED_LIST+=("$repo|$tag|new")
+                  echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"failed\",\"action\":\"new\",\"error\":\"$UPLOAD_ERR\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+                fi
+              fi
+            else
+              # Assets exist - compare content
+              REMOTE_HASH=$(gh release download "$tag" --repo "camaraproject/$repo" -p "release-metadata.yaml" -O - 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+              LOCAL_HASH=$(shasum -a 256 "$YAML_FILE" | cut -d' ' -f1)
+
+              if [[ "$REMOTE_HASH" == "$LOCAL_HASH" ]]; then
+                # Content identical - CURRENT
+                echo "✅  $repo/$tag - current"
+                CURRENT=$((CURRENT + 1))
+                CURRENT_LIST+=("$repo|$tag")
+                echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"current\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+              else
+                # Content differs - UPDATE
+                if [[ "$DRY_RUN" == "true" ]]; then
+                  echo "🔄  $repo/$tag - update (would replace)"
+                  UPDATE=$((UPDATE + 1))
+                  UPDATE_LIST+=("$repo|$tag")
+                  echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"update\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+                else
+                  echo -n "🔄  $repo/$tag - update, uploading... "
+                  UPLOAD_ERR=$(gh release upload "$tag" --repo "camaraproject/$repo" "$YAML_FILE" "$JSON_FILE" --clobber 2>&1) && UPLOAD_OK=true || UPLOAD_OK=false
+                  if [[ "$UPLOAD_OK" == "true" ]]; then
+                    echo "✓"
+                    UPLOADED=$((UPLOADED + 1))
+                    UPLOADED_LIST+=("$repo|$tag|update")
+                    echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"uploaded\",\"action\":\"update\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+                  else
+                    echo "✗"
+                    echo "    Error: $UPLOAD_ERR"
+                    FAILED=$((FAILED + 1))
+                    FAILED_LIST+=("$repo|$tag|update")
+                    echo "{\"repository\":\"$repo\",\"tag\":\"$tag\",\"status\":\"failed\",\"action\":\"update\",\"error\":\"$UPLOAD_ERR\",\"mode\":\"$MODE_LABEL\"}" >> "$REPORT_JSONL"
+                  fi
+                fi
+              fi
+            fi
+          done
+
+          # Generate markdown summary
+          echo "## Summary" >> "$REPORT_MD"
+          echo "" >> "$REPORT_MD"
+          echo "| Status | Count |" >> "$REPORT_MD"
+          echo "|--------|-------|" >> "$REPORT_MD"
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "| New (would upload) | $NEW |" >> "$REPORT_MD"
+            echo "| Update (would replace) | $UPDATE |" >> "$REPORT_MD"
+          else
+            echo "| Uploaded | $UPLOADED |" >> "$REPORT_MD"
+            echo "| Failed | $FAILED |" >> "$REPORT_MD"
+          fi
+          echo "| Current (no action) | $CURRENT |" >> "$REPORT_MD"
+          echo "| No release | $NO_RELEASE |" >> "$REPORT_MD"
+          echo "" >> "$REPORT_MD"
+
+          # Generate details section
+          echo "## Details" >> "$REPORT_MD"
+          echo "" >> "$REPORT_MD"
+
+          # Helper function to write table
+          write_table() {
+            local title="$1"
+            local count="$2"
+            shift 2
+            local items=("$@")
+            if [[ $count -gt 0 ]]; then
+              echo "### $title ($count)" >> "$REPORT_MD"
+              echo "" >> "$REPORT_MD"
+              echo "| Repository | Tag |" >> "$REPORT_MD"
+              echo "|------------|-----|" >> "$REPORT_MD"
+              for item in "${items[@]}"; do
+                IFS='|' read -r r t _ <<< "$item"
+                echo "| $r | $t |" >> "$REPORT_MD"
+              done
+              echo "" >> "$REPORT_MD"
+            fi
+          }
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            write_table "New" $NEW "${NEW_LIST[@]}"
+            write_table "Update" $UPDATE "${UPDATE_LIST[@]}"
+          else
+            write_table "Uploaded" $UPLOADED "${UPLOADED_LIST[@]}"
+            write_table "Failed" $FAILED "${FAILED_LIST[@]}"
+          fi
+          write_table "Current" $CURRENT "${CURRENT_LIST[@]}"
+          write_table "No Release" $NO_RELEASE "${NO_RELEASE_LIST[@]}"
+
+          # Console summary
+          echo ""
+          echo "=== Upload Analysis ==="
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "New (would upload):    $NEW"
+            echo "Update (would replace): $UPDATE"
+          else
+            echo "Uploaded:              $UPLOADED"
+            echo "Failed:                $FAILED"
+          fi
+          echo "Current (no action):   $CURRENT"
+          echo "No release:            $NO_RELEASE"
+
+          # Set outputs
+          echo "new=$NEW" >> $GITHUB_OUTPUT
+          echo "update=$UPDATE" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "no_release=$NO_RELEASE" >> $GITHUB_OUTPUT
           echo "uploaded=$UPLOADED" >> $GITHUB_OUTPUT
           echo "failed=$FAILED" >> $GITHUB_OUTPUT
 
           if [[ $FAILED -gt 0 ]]; then
-            echo "::warning::Some uploads failed. Check logs for details."
+            echo "::warning::Some uploads failed. Check report for details."
           fi
+          if [[ $NO_RELEASE -gt 0 ]]; then
+            echo "::warning::Some releases don't exist. Check report for details."
+          fi
+
+      - name: Upload report artifact
+        if: steps.check.outputs.has_artifacts == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata-upload-report-${{ github.run_number }}
+          path: |
+            reports/upload-report.md
+            reports/upload-report.jsonl
+          retention-days: 30
 
   # =========================================================================================
   # Job 5: Workflow Summary
@@ -513,6 +674,7 @@ jobs:
       - name: Generate summary
         run: |
           DRY_RUN="${{ github.event.inputs.dry_run }}"
+          DEPLOY_VIEWERS="${{ github.event.inputs.deploy_viewers }}"
           DEPLOY_MODE="${{ needs.validate-deployment.outputs.deploy_mode }}"
           DEPLOY_REF="${{ needs.validate-deployment.outputs.deploy_ref }}"
           DEPLOY_SHA="${{ needs.validate-deployment.outputs.deploy_sha }}"
@@ -520,9 +682,14 @@ jobs:
           STAGING_TS="${{ needs.validate-deployment.outputs.staging_timestamp }}"
           SKIP_DEPLOY="${{ needs.validate-deployment.outputs.skip_deploy }}"
           VALIDATION_RESULT="${{ needs.validate-deployment.result }}"
+          GENERATE_VIEWERS_RESULT="${{ needs.generate-viewers.result }}"
           DEPLOYED="${{ needs.deploy-production.outputs.deployed }}"
           COMMIT_URL="${{ needs.deploy-production.outputs.commit_url }}"
           UPLOAD_RESULT="${{ needs.upload-release-metadata.result }}"
+          NEW_COUNT="${{ needs.upload-release-metadata.outputs.new_count }}"
+          UPDATE_COUNT="${{ needs.upload-release-metadata.outputs.update_count }}"
+          CURRENT_COUNT="${{ needs.upload-release-metadata.outputs.current_count }}"
+          NO_RELEASE_COUNT="${{ needs.upload-release-metadata.outputs.no_release_count }}"
           UPLOADED_COUNT="${{ needs.upload-release-metadata.outputs.uploaded_count }}"
           FAILED_COUNT="${{ needs.upload-release-metadata.outputs.failed_count }}"
 
@@ -578,9 +745,21 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Files deployed (only show when validation passed)
-          if [[ "$VALIDATION_FAILED" != "true" ]]; then
-            echo "### Files Deployed" >> $GITHUB_STEP_SUMMARY
+          # Files deployed (only show when viewers were generated/deployed)
+          # Show if: deploy_viewers enabled AND (dry-run OR generate-viewers succeeded)
+          SHOW_FILES="false"
+          if [[ "$DEPLOY_VIEWERS" != "false" && "$VALIDATION_FAILED" != "true" ]]; then
+            if [[ "$DRY_RUN" == "true" || "$GENERATE_VIEWERS_RESULT" == "success" ]]; then
+              SHOW_FILES="true"
+            fi
+          fi
+
+          if [[ "$SHOW_FILES" == "true" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "### Files (would be deployed)" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### Files Deployed" >> $GITHUB_STEP_SUMMARY
+            fi
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "| File | Description |" >> $GITHUB_STEP_SUMMARY
             echo "|------|-------------|" >> $GITHUB_STEP_SUMMARY
@@ -593,13 +772,30 @@ jobs:
           fi
 
           # Metadata upload results
-          if [[ "$UPLOAD_RESULT" == "success" && -n "$UPLOADED_COUNT" ]]; then
+          if [[ "$UPLOAD_RESULT" == "success" ]]; then
             echo "### Release Metadata Upload" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "- Uploaded: $UPLOADED_COUNT releases" >> $GITHUB_STEP_SUMMARY
-            if [[ "$FAILED_COUNT" -gt 0 ]]; then
-              echo "- Failed: $FAILED_COUNT releases (check logs)" >> $GITHUB_STEP_SUMMARY
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "**Mode:** Dry run (no changes made)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Status | Count |" >> $GITHUB_STEP_SUMMARY
+              echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+              echo "| New (would upload) | ${NEW_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+              echo "| Update (would replace) | ${UPDATE_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+              echo "| Current (no action) | ${CURRENT_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+              echo "| No release | ${NO_RELEASE_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "**Mode:** Apply" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Status | Count |" >> $GITHUB_STEP_SUMMARY
+              echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+              echo "| Uploaded | ${UPLOADED_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+              echo "| Failed | ${FAILED_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+              echo "| Current (no action) | ${CURRENT_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+              echo "| No release | ${NO_RELEASE_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
             fi
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "See artifact **release-metadata-upload-report** for details." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           elif [[ "$UPLOAD_RESULT" == "skipped" ]]; then
             echo "### Release Metadata Upload" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -129,24 +129,28 @@ jobs:
         run: |
           npm install js-yaml axios @octokit/rest
 
-      - name: Detect releases
+      - name: Detect repositories and releases
         id: detect
         run: |
-          echo "🔍 Detecting releases in analysis scope: ${{ env.ANALYSIS_SCOPE }}"
+          echo "🔍 Detecting repositories and releases in analysis scope: ${{ env.ANALYSIS_SCOPE }}"
 
           # Create temp directory
           mkdir -p temp
 
-          # Run detection script
+          # Run detection script (also outputs repositories list)
           node workflows/release-collector/scripts/detect-releases.js --mode ${{ env.ANALYSIS_SCOPE }} > temp/detection-output.json
 
           # Parse output
           HAS_UPDATES=$(jq -r '.has_updates' temp/detection-output.json)
           RELEASES_TO_ANALYZE=$(jq -c '.releases_to_analyze' temp/detection-output.json)
           RELEASES_COUNT=$(jq -r '.releases_count' temp/detection-output.json)
+          REPOS_COUNT=$(jq -r '.repositories_count' temp/detection-output.json)
 
           echo "has_updates=${HAS_UPDATES}" >> $GITHUB_OUTPUT
           echo "releases_to_analyze=${RELEASES_TO_ANALYZE}" >> $GITHUB_OUTPUT
+
+          # Extract repositories list for update-master.js
+          jq '{repositories: .repositories}' temp/detection-output.json > temp/repositories.json
 
           # Create release groups for parallel processing
           # Split into groups of 20 releases
@@ -161,7 +165,13 @@ jobs:
           " > temp/release-groups.json
 
           echo "release_groups=$(cat temp/release-groups.json)" >> $GITHUB_OUTPUT
-          echo "Found ${RELEASES_COUNT} releases to analyze"
+          echo "Found ${RELEASES_COUNT} releases to analyze across ${REPOS_COUNT} repositories"
+
+      - name: Upload repositories data
+        uses: actions/upload-artifact@v4
+        with:
+          name: repositories-data
+          path: temp/repositories.json
 
   # =========================================================================================
   # Phase 2: Release Analysis (Parallel)
@@ -267,8 +277,19 @@ jobs:
             fi
           done
 
-          # Update master metadata (format corrections already applied by analyze-release.js)
-          node workflows/release-collector/scripts/update-master.js --mode ${{ env.ANALYSIS_SCOPE }} --input temp/combined-analysis.json
+          # Get repositories data (uploaded by detect-releases job)
+          REPOS_FILE="temp/repositories-data/repositories.json"
+          if [[ ! -f "$REPOS_FILE" ]]; then
+            echo "ERROR: repositories.json not found"
+            exit 1
+          fi
+          echo "Using $(jq '.repositories | length' $REPOS_FILE) repositories"
+
+          # Update master metadata with release_type and repositories
+          node workflows/release-collector/scripts/update-master.js \
+            --mode ${{ env.ANALYSIS_SCOPE }} \
+            --input temp/combined-analysis.json \
+            --repos "$REPOS_FILE"
 
           echo "Master metadata updated with $(jq '. | length' temp/combined-analysis.json) releases"
 

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -524,7 +524,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           branch: meta-release-update-${{ github.run_number }}
-          title: 'chore: Update CAMARA release metadata'
+          title: 'Review: CAMARA release data updates from Release Collector bot'
           labels: automated
           body: |
             ## CAMARA Release Metadata Update
@@ -581,7 +581,7 @@ jobs:
 
             *This PR was generated automatically by the Release Collector v3 workflow.*
           commit-message: |
-            chore: Update CAMARA release metadata
+            Review: CAMARA release data updates from Release Collector bot
 
             Analysis scope: ${{ env.ANALYSIS_SCOPE }}
             Workflow run: ${{ github.run_number }}

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -56,6 +56,12 @@ on:
         type: boolean
         default: false
 
+      force_metadata:
+        description: 'Force metadata regeneration even if no data updates'
+        required: false
+        type: boolean
+        default: false
+
   schedule:
     # Daily run at 04:35 UTC (for testing)
     - cron: '35 4 * * *'
@@ -67,6 +73,7 @@ env:
   EXECUTION_MODE: ${{ github.event.inputs.execution_mode || 'pr' }}
   DEBUG_MODE: ${{ github.event.inputs.debug_mode || 'false' }}
   FORCE_VIEWERS: ${{ github.event.inputs.force_viewers || 'false' }}
+  FORCE_METADATA: ${{ github.event.inputs.force_metadata || 'false' }}
 
   # GitHub API Configuration
   GITHUB_ORG: 'camaraproject'
@@ -308,6 +315,58 @@ jobs:
             reports/*.json
 
   # =========================================================================================
+  # Phase 3b: Generate Release Metadata Files
+  # Create release-metadata.yaml/.json for GitHub release uploads
+  # Always regenerates ALL files - diff shows what changed
+  # =========================================================================================
+  generate-release-metadata:
+    name: Generate Release Metadata
+    needs: [detect-releases, update-metadata]
+    if: |
+      always() &&
+      (needs.update-metadata.result == 'success' ||
+       (github.event.inputs.force_metadata || 'false') == 'true')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download processed data
+        if: needs.update-metadata.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: processed-data
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install js-yaml
+
+      - name: Generate release metadata files
+        run: |
+          echo "📄 Generating release-metadata files for ALL releases..."
+
+          node workflows/release-collector/scripts/generate-release-metadata.js
+
+          # Show summary
+          echo ""
+          echo "Generated files:"
+          find data/release-artifacts -name "*.yaml" -o -name "*.json" | head -20
+          TOTAL=$(find data/release-artifacts -name "*.yaml" | wc -l | tr -d ' ')
+          echo "Total releases with metadata: $TOTAL"
+
+      - name: Upload release metadata artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata-${{ github.run_number }}
+          path: data/release-artifacts/
+          retention-days: 30
+
+  # =========================================================================================
   # Phase 4: Generate Viewers
   # Generate HTML viewers with embedded data
   # =========================================================================================
@@ -363,8 +422,11 @@ jobs:
   # =========================================================================================
   publish-changes:
     name: Publish Changes
-    needs: generate-viewers
-    if: (github.event.inputs.execution_mode || 'pr') != 'dry-run'
+    needs: [generate-viewers, generate-release-metadata]
+    if: |
+      always() &&
+      (github.event.inputs.execution_mode || 'pr') != 'dry-run' &&
+      needs.generate-viewers.result == 'success'
     runs-on: ubuntu-latest
     outputs:
       pr_url: ${{ steps.create-pr.outputs.pull-request-url }}
@@ -378,6 +440,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-reports-${{ github.run_number }}
+
+      - name: Download release metadata (if generated)
+        if: needs.generate-release-metadata.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: release-metadata-${{ github.run_number }}
+          path: data/release-artifacts
 
       - name: Validate generated files
         if: env.EXECUTION_MODE == 'pr'
@@ -420,6 +489,7 @@ jobs:
           # Only commit data and reports (viewers are deployed separately in Phase 4)
           git add data/releases-master.yaml
           git add reports/*.json 2>/dev/null || true
+          git add data/release-artifacts/ 2>/dev/null || true
           # Note: viewers/*.html are gitignored and deployed to camaraproject.github.io
 
           if git diff --cached --quiet; then
@@ -469,8 +539,9 @@ jobs:
 
             - 📊 `data/releases-master.yaml` - Master release metadata
             - 📈 `reports/*.json` - Meta-release reports (Fall24, Spring25, Fall25, All)
+            - 📦 `data/release-artifacts/` - Per-release metadata files (if generated)
 
-            **Note**: Viewers are deployed to staging for preview. After merging, trigger the **Release Collector - Production Deploy** workflow to publish to https://camaraproject.github.io/releases/
+            **Note**: Viewers are deployed to staging for preview. After merging, trigger the **Release Collector - Production Deploy** workflow to publish viewers and upload metadata to GitHub releases.
 
             ### File Changes
 

--- a/config/api-landscape.yaml
+++ b/config/api-landscape.yaml
@@ -201,7 +201,7 @@ apis:
   qos-booking-and-assignment:
     category: Communication Quality
     website_url: https://camaraproject.org/qos-booking-and-assignment/
-    tooltip: Request an assignment of a certain QoS Profile to a certain device (test change)
+    tooltip: Request an assignment of a certain QoS Profile to a certain device
     published: true
     first_release: Fall25
   connectivity-insights:

--- a/workflows/release-collector/MAINTAINER-FAQ.md
+++ b/workflows/release-collector/MAINTAINER-FAQ.md
@@ -12,9 +12,9 @@ See [User Guide](docs/README.md#typical-workflows) for scheduling details.
 
 ### 2. What's the difference between incremental and full mode?
 
-**Incremental**: Only processes new releases (fast, 2-5 minutes). Use for regular updates.
+**Incremental**: Only processes new releases (fast, 1-2 minutes). Use for regular updates.
 
-**Full**: Re-analyzes all releases (5-15 minutes). Use after configuration changes or to fix data.
+**Full**: Re-analyzes all releases (3-5 minutes). Use after configuration changes or to fix data.
 
 See [User Guide](docs/README.md#analysis-scope) for complete details.
 
@@ -94,12 +94,12 @@ Pre-releases are only visible in the **internal viewer**, which shows the releas
 Release types:
 - `pre-release-alpha` - Early development (version contains `-alpha.N`)
 - `pre-release-rc` - Release candidate (version contains `-rc.N`)
-- `public-release` - Stable release
+- `public-release` - Public release of initial or stable API versions
 - `maintenance-release` - Release on maintenance branch
 
 ### 14. Why don't I see r0.X releases?
 
-r0.X releases are excluded from collection - they represent early development work before the first formal release.
+Formal releases start at r1.1. Two existing r0.X releases are excluded from the collection - they were pre-releases accidentially created with these non-valid release tags.
 
 ## Production Deployment
 
@@ -130,11 +130,11 @@ Only `data/releases-master.yaml`, `data/release-artifacts/`, and `reports/*.json
 
 ### 19. How do I check what changed in a specific meta-release?
 
-Compare the JSON reports in the PR diff (`reports/fall24.json`, `reports/spring25.json`, etc.). The diff shows new APIs, version changes, and maturity changes.
+For new APIs within a meta-release you can use the meta-release viewer and order the "New" column with "True" values on top. To see the evolution of APIs across meta-releases use the Portfolio viewer.
 
 ### 20. The workflow is taking too long
 
-Normal times: 2-5 minutes (incremental), 5-15 minutes (full). If longer, check for API rate limits in logs or network issues.
+See FAQ #2 for normal times. If significantly longer, check for API rate limits in logs or network issues.
 
 See [User Guide](docs/README.md#workflow-timeout-or-very-slow) for troubleshooting.
 

--- a/workflows/release-collector/MAINTAINER-FAQ.md
+++ b/workflows/release-collector/MAINTAINER-FAQ.md
@@ -83,17 +83,56 @@ See [User Guide](docs/README.md#no-pr-created-even-though-i-expected-changes) fo
 
 Yes! Use **execution_mode: dry-run** to run the workflow completely without committing or creating a PR. Download artifacts to review results.
 
+## Pre-Releases and Release Types
+
+### 13. How do pre-releases appear in the viewers?
+
+Pre-releases are only visible in the **internal viewer**, which shows the release type as a text label (not a badge). The internal viewer allows filtering by release type.
+
+**Note**: Closed meta-releases (Fall24) contain only public and maintenance releases - pre-releases are only relevant for open/upcoming meta-releases.
+
+Release types:
+- `pre-release-alpha` - Early development (version contains `-alpha.N`)
+- `pre-release-rc` - Release candidate (version contains `-rc.N`)
+- `public-release` - Stable release
+- `maintenance-release` - Release on maintenance branch
+
+### 14. Why don't I see r0.X releases?
+
+r0.X releases are excluded from collection - they represent early development work before the first formal release.
+
+## Production Deployment
+
+### 15. What happens during production deploy?
+
+The **Release Collector - Production Deploy** workflow does two things:
+1. Deploys HTML viewers to camaraproject.github.io
+2. Uploads release-metadata files (YAML/JSON) to each GitHub release as assets
+
+### 16. Upload shows FAILED - what went wrong?
+
+Common causes:
+- **403 Forbidden**: Token lacks write permission for repository. The `PRODUCTION_DEPLOY_TOKEN` needs **Contents: Read and Write** permission.
+- **404 Not Found**: Release doesn't exist in the repository.
+- **Network errors**: Retry the workflow.
+
+Check the workflow logs and upload report artifact for the specific error message.
+
+### 17. Can I re-upload release metadata?
+
+Yes. The upload uses `--clobber` mode, so running production deploy again will replace existing metadata files. The workflow shows **UPDATE** status for releases where files exist but content differs.
+
 ## Advanced
 
-### 13. What files does the workflow commit?
+### 18. What files does the workflow commit?
 
-Only `data/releases-master.yaml` and `reports/*.json`. Viewers are NOT committed (available in artifacts and staging deployment).
+Only `data/releases-master.yaml`, `data/release-artifacts/`, and `reports/*.json`. Viewers are NOT committed (available in artifacts and staging deployment).
 
-### 14. How do I check what changed in a specific meta-release?
+### 19. How do I check what changed in a specific meta-release?
 
 Compare the JSON reports in the PR diff (`reports/fall24.json`, `reports/spring25.json`, etc.). The diff shows new APIs, version changes, and maturity changes.
 
-### 15. The workflow is taking too long
+### 20. The workflow is taking too long
 
 Normal times: 2-5 minutes (incremental), 5-15 minutes (full). If longer, check for API rate limits in logs or network issues.
 

--- a/workflows/release-collector/QUICKSTART.md
+++ b/workflows/release-collector/QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ## What This Does
 
-Automatically tracks all CAMARA API releases across repositories, categorizes them by meta-release (Fall24, Spring25, Fall25), and generates browsable HTML viewers.
+Automatically tracks all CAMARA API releases across repositories (including pre-releases), categorizes them by meta-release (Fall24, Spring25, Fall25), and generates browsable HTML viewers. Also generates release-metadata files for each release.
 
 ## Scheduled Runs
 
@@ -47,11 +47,12 @@ When new releases are detected, a PR is created automatically. Maintainers recei
 3. **What Happens Next**
 
    - Workflow runs for 5-15 minutes
-   - You'll see 7 phases execute in the Actions UI:
-     - Detect → Analyze (parallel) → Update → Generate Viewers → Publish → Deploy Staging → Summary
+   - You'll see 8 phases execute in the Actions UI:
+     - Detect → Analyze (parallel) → Update → Generate Metadata → Generate Viewers → Publish → Deploy Staging → Summary
    - If updates found: Creates a PR with title "chore: Update CAMARA release metadata"
    - If no updates: Workflow completes without PR
    - Viewers available for preview at staging GitHub Pages URLs (in PR description)
+   - Release-metadata files (YAML/JSON) staged for each release in `data/release-artifacts/`
 
    ![Workflow phases visualization](docs/images/workflow-visualization.png)
 
@@ -63,18 +64,30 @@ Then: **Squash and merge** to keep history clean
 
 ## After Merging - Deploy to Production
 
-After merging the PR, deploy viewers to the public site:
+After merging the PR, deploy viewers and upload release metadata to the public site:
 
 1. **Navigate to Actions**
    - Go to: github.com/camaraproject/project-administration
    - Click **Actions** tab → **Release Collector - Production Deploy** → **Run workflow**
 
-2. **Use default settings** (recommended)
-   - Validates staging content matches main branch before deploying
+2. **Configure options** (defaults are usually fine)
+
+   | Option | Default | Description |
+   |--------|---------|-------------|
+   | `deploy_viewers` | `true` | Deploy HTML viewers to production |
+   | `upload_metadata` | `true` | Upload release-metadata to GitHub releases |
+   | `upload_releases` | (empty) | Filter: e.g., "QualityOnDemand/r1.2". Empty = all |
+   | `ref` | (empty) | Rollback: deploy specific commit from main history |
+   | `allow_branch` | `false` | Emergency: skip safety checks, deploy from any branch |
+   | `dry_run` | `false` | Preview mode: show what would happen |
 
 3. **What Happens**
    - Viewers are published to: https://camaraproject.github.io/releases/
    - Links: [Fall24](https://camaraproject.github.io/releases/fall24.html) | [Spring25](https://camaraproject.github.io/releases/spring25.html) | [Fall25](https://camaraproject.github.io/releases/fall25.html)
+   - Release-metadata files (YAML/JSON) uploaded to each GitHub release as assets
+   - Upload report artifact generated showing NEW/UPDATE/CURRENT status for each release
+
+   **Safety**: By default, the workflow validates that staging content matches main branch before deploying.
 
 ## When to Use Full Re-analysis
 

--- a/workflows/release-collector/QUICKSTART.md
+++ b/workflows/release-collector/QUICKSTART.md
@@ -46,10 +46,10 @@ When new releases are detected, a PR is created automatically. Maintainers recei
 
 3. **What Happens Next**
 
-   - Workflow runs for 5-15 minutes
+   - Workflow runs for 3-5 minutes
    - You'll see 8 phases execute in the Actions UI:
      - Detect → Analyze (parallel) → Update → Generate Metadata → Generate Viewers → Publish → Deploy Staging → Summary
-   - If updates found: Creates a PR with title "chore: Update CAMARA release metadata"
+   - If updates found: Creates a PR with title "Review: CAMARA release data updates from Release Collector bot"
    - If no updates: Workflow completes without PR
    - Viewers available for preview at staging GitHub Pages URLs (in PR description)
    - Release-metadata files (YAML/JSON) staged for each release in `data/release-artifacts/`
@@ -77,9 +77,9 @@ After merging the PR, deploy viewers and upload release metadata to the public s
    | `deploy_viewers` | `true` | Deploy HTML viewers to production |
    | `upload_metadata` | `true` | Upload release-metadata to GitHub releases |
    | `upload_releases` | (empty) | Filter: e.g., "QualityOnDemand/r1.2". Empty = all |
-   | `ref` | (empty) | Rollback: deploy specific commit from main history |
-   | `allow_branch` | `false` | Emergency: skip safety checks, deploy from any branch |
-   | `dry_run` | `false` | Preview mode: show what would happen |
+   | `ref` | (empty) | Used only for rollback: commit SHA from main history. Leave empty for normal deployment (latest from main branch) |
+   | `allow_branch` | `false` | Emergency or test: set `true` to deploy from current branch instead of main |
+   | `dry_run` | `false` | Preview mode: set `true` to show what would happen without deploying |
 
 3. **What Happens**
    - Viewers are published to: https://camaraproject.github.io/releases/
@@ -89,7 +89,7 @@ After merging the PR, deploy viewers and upload release metadata to the public s
 
    **Safety**: By default, the workflow validates that staging content matches main branch before deploying.
 
-## When to Use Full Re-analysis
+## When to Use Full Analysis
 
 > **Important**: Config file changes are NOT automatically detected. You MUST manually run a full analysis after changing any config file - scheduled runs (incremental) will not pick up these changes.
 

--- a/workflows/release-collector/docs/README.md
+++ b/workflows/release-collector/docs/README.md
@@ -63,7 +63,7 @@ Force viewers: true
 ### If PR is Created
 
 1. **Navigate to the PR**
-   - Look for "chore: Update CAMARA release metadata" PR
+   - Look for "Review: CAMARA release data updates from Release Collector bot" PR
    - Check the PR description for staging viewer links
 
 2. **Review Changes** (checklist):
@@ -110,7 +110,7 @@ For testing or manual review:
 **What it does**:
 - Detects only NEW releases since last run
 - Compares current GitHub state with `data/releases-master.yaml`
-- Fast execution (typically 2-5 minutes)
+- Fast execution (typically 1-2 minutes)
 - Updates master metadata incrementally
 
 **Example**: If you ran the workflow last week and 3 new releases were published, incremental mode will only analyze those 3 releases.
@@ -125,7 +125,7 @@ For testing or manual review:
 **What it does**:
 - Re-analyzes ALL releases across all repositories
 - Ignores current state of releases-master.yaml
-- Longer execution (typically 5-10 minutes)
+- Longer execution (typically 3-5 minutes)
 - Rebuilds master metadata from scratch
 
 **Example**: After updating api-landscape.yaml with new category assignments, use full mode to regenerate all reports with the new categories.
@@ -153,7 +153,7 @@ For testing or manual review:
 - Creates pull request for review
 - Requires approval before deployment
 
-**PR title**: `chore: Update CAMARA release metadata`
+**PR title**: `Review: CAMARA release data updates from Release Collector bot`
 
 **Safety features**:
 - Diff detection prevents empty PRs
@@ -324,11 +324,11 @@ The collector tracks all release types, not just public releases:
 |--------------|-----------|-------------|
 | `pre-release-alpha` | API version contains `-alpha.N` | r1.1 with version `0.5.0-alpha.1` |
 | `pre-release-rc` | API version contains `-rc.N` | r1.1 with version `1.0.0-rc.1` |
-| `public-release` | Stable version, not on maintenance branch | r1.2 with version `1.0.0` |
+| `public-release` | Initial or stable version, not on maintenance branch | r1.2 with version `1.0.0` |
 | `maintenance-release` | Release on `maintenance/rX.Y` branch | r1.2 on maintenance/r1.2 |
 
 **Notes:**
-- r0.X tags are excluded (early development, not tracked)
+- r0.X tags are excluded (invalid release tags, not tracked)
 - Pre-releases appear in viewers with release type badges
 - Internal viewer allows filtering by release type
 
@@ -419,7 +419,7 @@ Result: Artifact download for testing
 - Check GitHub API rate limit status
 - Verify parallel jobs are running (max 6)
 - Network issues may slow API calls
-- Full re-analysis of 80+ releases takes 5-15 minutes (normal)
+- Full re-analysis takes 3-5 minutes (see [Analysis Scope](#analysis-scope))
 
 ### PR merge conflicts
 **Cause**: Multiple workflow runs or manual edits to master YAML
@@ -492,10 +492,7 @@ These corrections are hardcoded and applied to all releases automatically. No co
 ## Maintenance
 
 ### Adding New Meta-Releases
-1. Update `/config/meta-release-mappings.yaml`
-2. Update `scripts/generate-reports.js` (add meta-release to list)
-3. Update `scripts/generate-viewers.js` (add template generation)
-4. Run full re-analysis
+See [issue #100](https://github.com/camaraproject/project-administration/issues/100) for the future enhancement for upcoming meta-releases.
 
 ### Adding New APIs
 1. Add to `/config/api-landscape.yaml`
@@ -523,11 +520,11 @@ Schema 2.0.0 includes property name alignment (per [#69](https://github.com/cama
 - `release_type`: Classification (pre-release-alpha, pre-release-rc, public-release, maintenance-release)
 - `repositories`: Array of all repos with quick-reference release pointers
 
-**Property renames:**
+**Property changes in master-metadata-schema:**
 | Old Name | New Name | Location |
 |----------|----------|----------|
-| `commonalities_version` | `commonalities` | releases array |
-| `api_version` | `version` | apis array |
+| `version` | `api_version` | apis array |
+| `title` | `api_title` | apis array |
 
 **New output:**
 - `release-metadata.yaml` / `.json` generated for each release

--- a/workflows/release-collector/docs/README.md
+++ b/workflows/release-collector/docs/README.md
@@ -325,7 +325,7 @@ The collector tracks all release types, not just public releases:
 | `pre-release-alpha` | API version contains `-alpha.N` | r1.1 with version `0.5.0-alpha.1` |
 | `pre-release-rc` | API version contains `-rc.N` | r1.1 with version `1.0.0-rc.1` |
 | `public-release` | Initial or stable version, not on maintenance branch | r1.2 with version `1.0.0` |
-| `maintenance-release` | Release on `maintenance/rX.Y` branch | r1.2 on maintenance/r1.2 |
+| `maintenance-release` | Release on `maintenance-rX` branch for release cycle X | r1.3 on maintenance-r1 with version `1.0.1` |
 
 **Notes:**
 - r0.X tags are excluded (invalid release tags, not tracked)

--- a/workflows/release-collector/docs/architecture/0002-runtime-enrichment-architecture.md
+++ b/workflows/release-collector/docs/architecture/0002-runtime-enrichment-architecture.md
@@ -285,7 +285,7 @@ function enrichAPI(apiData, landscape) {
 
 2. **Full re-analysis needed**
    - Portfolio changes require full re-analysis to regenerate reports
-   - Longer workflow run (5-10 minutes vs 2-5 minutes)
+   - Longer workflow run (3-5 minutes vs 1-2 minutes)
    - Acceptable for weekly/manual updates
 
 3. **Complexity in generate-reports.js**

--- a/workflows/release-collector/schemas/master-metadata-schema.yaml
+++ b/workflows/release-collector/schemas/master-metadata-schema.yaml
@@ -1,6 +1,10 @@
 # Master Metadata Schema
 # Schema for releases-master.yaml containing GitHub facts with format corrections only
-# Version: 1.1.0
+# Version: 2.0.0
+#
+# Changes in 2.0.0:
+# - Renamed 'version' to 'api_version' in APIs array (per issue #69 property alignment)
+# - Renamed 'title' to 'api_title' in APIs array (per issue #69 property alignment)
 #
 # Changes in 1.1.0:
 # - Added release_type field to releases (pre-release-alpha, pre-release-rc, public-release, maintenance-release)
@@ -103,7 +107,7 @@ properties:
             type: object
             required:
               - file_name
-              - version
+              - api_version
             properties:
               api_name:
                 type: ["string", "null"]
@@ -117,7 +121,7 @@ properties:
                 pattern: "^[a-zA-Z][a-zA-Z0-9-_]*$"
                 description: Original YAML filename without extension
 
-              version:
+              api_version:
                 type: string
                 pattern: "^\\d+\\.\\d+\\.\\d+(-[a-z]+\\.\\d+)?$"
                 description: |
@@ -125,7 +129,7 @@ properties:
                   'v' prefix is removed if present (v0.11.0 → 0.11.0).
                   Pre-release extensions follow pattern: X.Y.Z-alpha.N or X.Y.Z-rc.N
 
-              title:
+              api_title:
                 type: ["string", "null"]
                 description: Human-readable API title from OpenAPI spec
 

--- a/workflows/release-collector/schemas/master-metadata-schema.yaml
+++ b/workflows/release-collector/schemas/master-metadata-schema.yaml
@@ -1,6 +1,11 @@
 # Master Metadata Schema
 # Schema for releases-master.yaml containing GitHub facts with format corrections only
-# Version: 1.0.0
+# Version: 1.1.0
+#
+# Changes in 1.1.0:
+# - Added release_type field to releases (pre-release-alpha, pre-release-rc, public-release, maintenance-release)
+# - Added repositories array with minimal release reference pointers (latest_public_release, newest_pre_release)
+# - Extended version pattern to support pre-release extensions (-alpha.N, -rc.N)
 
 $schema: http://json-schema.org/draft-07/schema#
 title: CAMARA Master Metadata
@@ -76,6 +81,20 @@ properties:
           pattern: "^https://github\\.com/camaraproject/.*"
           description: Direct link to GitHub release
 
+        release_type:
+          type: string
+          enum:
+            - pre-release-alpha
+            - pre-release-rc
+            - public-release
+            - maintenance-release
+          description: |
+            Classification of the release based on API versions and position in release cycle.
+            - pre-release-alpha: GitHub prerelease with API versions containing -alpha extension
+            - pre-release-rc: GitHub prerelease with API versions containing -rc extension
+            - public-release: First non-prerelease in a release cycle (rX)
+            - maintenance-release: Subsequent non-prereleases in the same cycle
+
         apis:
           type: array
           description: API specifications in this release
@@ -100,10 +119,11 @@ properties:
 
               version:
                 type: string
-                pattern: "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9]+)?$"
+                pattern: "^\\d+\\.\\d+\\.\\d+(-[a-z]+\\.\\d+)?$"
                 description: |
                   Semantic version with format corrections applied.
-                  'v' prefix is removed if present (v0.11.0 → 0.11.0)
+                  'v' prefix is removed if present (v0.11.0 → 0.11.0).
+                  Pre-release extensions follow pattern: X.Y.Z-alpha.N or X.Y.Z-rc.N
 
               title:
                 type: ["string", "null"]
@@ -115,3 +135,41 @@ properties:
                 description: |
                   CAMARA Commonalities version as string.
                   Numbers are converted to strings, existing strings preserved as-is.
+
+  repositories:
+    type: array
+    description: |
+      All CAMARA API repositories with quick-reference release pointers.
+      Minimal data focused on release tracking; comprehensive repository metadata is in a separate workflow.
+    items:
+      type: object
+      required:
+        - repository
+        - github_url
+      properties:
+        repository:
+          type: string
+          pattern: "^[A-Za-z][A-Za-z0-9-]*$"
+          description: GitHub repository name
+
+        github_url:
+          type: string
+          format: uri
+          pattern: "^https://github\\.com/camaraproject/.*"
+          description: URL to the GitHub repository
+
+        latest_public_release:
+          type: ["string", "null"]
+          pattern: "^r\\d+\\.\\d+$"
+          description: |
+            Tag of the most recent public-release or maintenance-release.
+            Null if repository has no public releases yet.
+
+        newest_pre_release:
+          type: ["string", "null"]
+          pattern: "^r\\d+\\.\\d+$"
+          description: |
+            Tag of the newest pre-release, only set if:
+            - Newer than latest_public_release (same cycle rX.Y+1 or next cycle rX+1.Y), OR
+            - latest_public_release is null (repo has only pre-releases)
+            Null if no relevant pre-release exists.

--- a/workflows/release-collector/scripts/analyze-release.js
+++ b/workflows/release-collector/scripts/analyze-release.js
@@ -82,7 +82,7 @@ function extractAPINameFromSpec(spec) {
  * - If ALL APIs are -rc.N or public (no extension) → 'pre-release-rc'
  * - If pre-release but no valid alpha/rc extensions → warn and classify as 'pre-release-alpha'
  *
- * @param {Array} apis - Array of API objects with version field
+ * @param {Array} apis - Array of API objects with api_version field
  * @param {boolean} isPrerelease - GitHub prerelease flag
  * @param {string} repository - Repository name for logging
  * @param {string} releaseTag - Release tag for logging
@@ -95,12 +95,12 @@ function determinePreReleaseType(apis, isPrerelease, repository, releaseTag) {
 
   // Check if any API has an alpha version extension
   const hasAlpha = apis.some(api =>
-    api.version && api.version.includes('-alpha.')
+    api.api_version && api.api_version.includes('-alpha.')
   );
 
   // Check if any API has an rc version extension
   const hasRc = apis.some(api =>
-    api.version && api.version.includes('-rc.')
+    api.api_version && api.api_version.includes('-rc.')
   );
 
   // If any API is alpha, the release can't be better than alpha
@@ -121,16 +121,16 @@ function determinePreReleaseType(apis, isPrerelease, repository, releaseTag) {
 /**
  * Apply format corrections to API data
  * These corrections are hardcoded and always applied:
- * 1. Remove 'v' prefix from version (v0.11.0 → 0.11.0)
+ * 1. Remove 'v' prefix from api_version (v0.11.0 → 0.11.0)
  * 2. Ensure commonalities is a string and correct format (0.4.0 → 0.4 for Fall24)
  * 3. Convert API names to lowercase for consistency
  */
 function applyFormatCorrections(api) {
   const corrected = { ...api };
 
-  // 1. Strip 'v' prefix from version if present
-  if (corrected.version && typeof corrected.version === 'string') {
-    corrected.version = corrected.version.replace(/^v/, '');
+  // 1. Strip 'v' prefix from api_version if present
+  if (corrected.api_version && typeof corrected.api_version === 'string') {
+    corrected.api_version = corrected.api_version.replace(/^v/, '');
   }
 
   // 2. Ensure commonalities is a string (convert numbers, preserve existing strings)
@@ -212,8 +212,8 @@ async function analyzeLocalRelease(repoPath, releaseTag, isPrerelease = false) {
         const apiData = {
           api_name: apiName || fileName,        // Use filename as fallback for legacy releases
           file_name: fileName,                  // Filename for consistency check
-          version: spec.info.version || 'unknown',
-          title: spec.info.title || 'Untitled',
+          api_version: spec.info.version || 'unknown',
+          api_title: spec.info.title || 'Untitled',
           commonalities: spec.info['x-camara-commonalities'] || null
         };
 
@@ -227,16 +227,16 @@ async function analyzeLocalRelease(repoPath, releaseTag, isPrerelease = false) {
           correctedApi.api_name = 'connectivity-insights-subscriptions';
         }
 
-        // Fix incorrect title for connectivity-insights-subscriptions in r1.2 and r2.2
+        // Fix incorrect api_title for connectivity-insights-subscriptions in r1.2 and r2.2
         if (repoName === 'ConnectivityInsights' && (releaseTag === 'r1.2' || releaseTag === 'r2.2') &&
-            correctedApi.file_name === 'connectivity-insights-subscriptions' && correctedApi.title === 'Connectivity Insights') {
-          console.error(`Applying correction: ConnectivityInsights ${releaseTag} - fixing title to 'Connectivity Insights Subscriptions'`);
-          correctedApi.title = 'Connectivity Insights Subscriptions';
+            correctedApi.file_name === 'connectivity-insights-subscriptions' && correctedApi.api_title === 'Connectivity Insights') {
+          console.error(`Applying correction: ConnectivityInsights ${releaseTag} - fixing api_title to 'Connectivity Insights Subscriptions'`);
+          correctedApi.api_title = 'Connectivity Insights Subscriptions';
         }
 
         // Exclude known invalid RC release
-        if (correctedApi.api_name === 'region-device-count' && correctedApi.version === '0.1.0-rc.1') {
-          console.error(`Excluding invalid RC release: ${correctedApi.api_name} ${correctedApi.version}`);
+        if (correctedApi.api_name === 'region-device-count' && correctedApi.api_version === '0.1.0-rc.1') {
+          console.error(`Excluding invalid RC release: ${correctedApi.api_name} ${correctedApi.api_version}`);
           continue;
         }
 
@@ -327,8 +327,8 @@ async function analyzeGitHubRelease(repository, releaseTag) {
         const apiData = {
           api_name: apiName || fileName,        // Use filename as fallback for legacy releases
           file_name: fileName,                  // Filename for consistency check
-          version: spec.info.version || 'unknown',
-          title: spec.info.title || 'Untitled',
+          api_version: spec.info.version || 'unknown',
+          api_title: spec.info.title || 'Untitled',
           commonalities: spec.info['x-camara-commonalities'] || null
         };
 
@@ -342,16 +342,16 @@ async function analyzeGitHubRelease(repository, releaseTag) {
           correctedApi.api_name = 'connectivity-insights-subscriptions';
         }
 
-        // Fix incorrect title for connectivity-insights-subscriptions in r1.2 and r2.2
+        // Fix incorrect api_title for connectivity-insights-subscriptions in r1.2 and r2.2
         if (repository === 'ConnectivityInsights' && (releaseTag === 'r1.2' || releaseTag === 'r2.2') &&
-            correctedApi.file_name === 'connectivity-insights-subscriptions' && correctedApi.title === 'Connectivity Insights') {
-          console.error(`Applying correction: ConnectivityInsights ${releaseTag} - fixing title to 'Connectivity Insights Subscriptions'`);
-          correctedApi.title = 'Connectivity Insights Subscriptions';
+            correctedApi.file_name === 'connectivity-insights-subscriptions' && correctedApi.api_title === 'Connectivity Insights') {
+          console.error(`Applying correction: ConnectivityInsights ${releaseTag} - fixing api_title to 'Connectivity Insights Subscriptions'`);
+          correctedApi.api_title = 'Connectivity Insights Subscriptions';
         }
 
         // Exclude known invalid RC release
-        if (correctedApi.api_name === 'region-device-count' && correctedApi.version === '0.1.0-rc.1') {
-          console.error(`Excluding invalid RC release: ${correctedApi.api_name} ${correctedApi.version}`);
+        if (correctedApi.api_name === 'region-device-count' && correctedApi.api_version === '0.1.0-rc.1') {
+          console.error(`Excluding invalid RC release: ${correctedApi.api_name} ${correctedApi.api_version}`);
           continue;
         }
 

--- a/workflows/release-collector/scripts/analyze-release.js
+++ b/workflows/release-collector/scripts/analyze-release.js
@@ -74,6 +74,51 @@ function extractAPINameFromSpec(spec) {
 }
 
 /**
+ * Determine pre-release type from API versions
+ * Pre-releases contain API versions with -alpha.N or -rc.N extensions
+ *
+ * Logic: A release is only as mature as its least mature API
+ * - If ANY API has -alpha.N extension → 'pre-release-alpha'
+ * - If ALL APIs are -rc.N or public (no extension) → 'pre-release-rc'
+ * - If pre-release but no valid alpha/rc extensions → warn and classify as 'pre-release-alpha'
+ *
+ * @param {Array} apis - Array of API objects with version field
+ * @param {boolean} isPrerelease - GitHub prerelease flag
+ * @param {string} repository - Repository name for logging
+ * @param {string} releaseTag - Release tag for logging
+ * @returns {string|null} 'pre-release-alpha' | 'pre-release-rc' | null (if not a pre-release)
+ */
+function determinePreReleaseType(apis, isPrerelease, repository, releaseTag) {
+  if (!isPrerelease) {
+    return null;  // Not a pre-release, type will be determined in update-master.js
+  }
+
+  // Check if any API has an alpha version extension
+  const hasAlpha = apis.some(api =>
+    api.version && api.version.includes('-alpha.')
+  );
+
+  // Check if any API has an rc version extension
+  const hasRc = apis.some(api =>
+    api.version && api.version.includes('-rc.')
+  );
+
+  // If any API is alpha, the release can't be better than alpha
+  if (hasAlpha) {
+    return 'pre-release-alpha';
+  }
+
+  // All APIs are rc → release is rc
+  if (hasRc) {
+    return 'pre-release-rc';
+  }
+
+  // No valid alpha or rc extension found (could be typo, missing number, or maintenance pre-release)
+  console.error(`⚠️ WARNING: ${repository} ${releaseTag} is marked as pre-release but contains neither a valid -alpha.N nor -rc.N API version. Classifying as pre-release-alpha.`);
+  return 'pre-release-alpha';
+}
+
+/**
  * Apply format corrections to API data
  * These corrections are hardcoded and always applied:
  * 1. Remove 'v' prefix from version (v0.11.0 → 0.11.0)
@@ -130,9 +175,12 @@ function getMetaRelease(repository, releaseTag, mappings) {
 
 /**
  * Analyze release from local repository (for testing)
+ * @param {string} repoPath - Path to local repository
+ * @param {string} releaseTag - Release tag to analyze
+ * @param {boolean} isPrerelease - Whether this is a pre-release (default: false)
  */
-async function analyzeLocalRelease(repoPath, releaseTag) {
-  console.error(`Analyzing local release: ${repoPath} @ ${releaseTag}`);
+async function analyzeLocalRelease(repoPath, releaseTag, isPrerelease = false) {
+  console.error(`Analyzing local release: ${repoPath} @ ${releaseTag} (prerelease: ${isPrerelease})`);
 
   const repoName = path.basename(repoPath);
 
@@ -208,11 +256,16 @@ async function analyzeLocalRelease(repoPath, releaseTag) {
   // Return back to main branch
   await execAsync('git checkout main --quiet', { cwd: repoPath });
 
+  // Determine release_type for pre-releases (public/maintenance determined in update-master.js)
+  const releaseType = determinePreReleaseType(apis, isPrerelease, repoName, releaseTag);
+
   return {
     repository: repoName,
     release_tag: releaseTag,
     release_date: releaseDate.trim(),
     github_url: `https://github.com/${GITHUB_ORG}/${repoName}/releases/tag/${releaseTag}`,
+    is_prerelease: isPrerelease,
+    release_type: releaseType,  // null for non-prereleases, determined in update-master.js
     apis: apis
   };
 }
@@ -309,11 +362,16 @@ async function analyzeGitHubRelease(repository, releaseTag) {
     }
   }
 
+  // Determine release_type for pre-releases (public/maintenance determined in update-master.js)
+  const releaseType = determinePreReleaseType(apis, release.prerelease, repository, releaseTag);
+
   return {
     repository: repository,
     release_tag: releaseTag,
     release_date: release.published_at,
     github_url: release.html_url,
+    is_prerelease: release.prerelease,
+    release_type: releaseType,  // null for non-prereleases, determined in update-master.js
     apis: apis
   };
 }
@@ -326,11 +384,12 @@ async function main() {
 
   if (args.length < 2) {
     console.error('Usage:');
-    console.error('  Local:  node analyze-release.js --local <repo-path> <release-tag>');
+    console.error('  Local:  node analyze-release.js --local <repo-path> <release-tag> [--prerelease]');
     console.error('  GitHub: node analyze-release.js --github <repo-name> <release-tag>');
     console.error('');
     console.error('Examples:');
     console.error('  node analyze-release.js --local /path/to/DeviceRoamingStatus r1.1');
+    console.error('  node analyze-release.js --local /path/to/DeviceRoamingStatus r1.1 --prerelease');
     console.error('  node analyze-release.js --github DeviceRoamingStatus r1.1');
     process.exit(1);
   }
@@ -340,8 +399,9 @@ async function main() {
 
   try {
     if (mode === '--local') {
-      const [, repoPath, releaseTag] = args;
-      result = await analyzeLocalRelease(repoPath, releaseTag);
+      const [, repoPath, releaseTag, ...rest] = args;
+      const isPrerelease = rest.includes('--prerelease');
+      result = await analyzeLocalRelease(repoPath, releaseTag, isPrerelease);
     } else if (mode === '--github') {
       const [, repoName, releaseTag] = args;
       result = await analyzeGitHubRelease(repoName, releaseTag);
@@ -371,5 +431,6 @@ module.exports = {
   extractAPINameFromSpec,
   extractFileName,
   applyFormatCorrections,
+  determinePreReleaseType,
   loadConfig
 };

--- a/workflows/release-collector/scripts/detect-releases.js
+++ b/workflows/release-collector/scripts/detect-releases.js
@@ -108,7 +108,7 @@ async function fetchReleases(repoName) {
     // Now includes pre-releases for visibility of release candidates
     const validReleases = data.filter(release =>
       !release.draft &&
-      /^r\d+\.\d+$/.test(release.tag_name)  // Only rX.Y format
+      /^r[1-9]\d*\.[1-9]\d*$/.test(release.tag_name)  // Only rX.Y format where X,Y >= 1
     );
 
     releases.push(...validReleases);

--- a/workflows/release-collector/scripts/generate-release-metadata.js
+++ b/workflows/release-collector/scripts/generate-release-metadata.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * Generate Release Metadata Script
+ *
+ * Generates release-metadata.yaml and release-metadata.json files for ALL releases.
+ * Conforms to the schema at:
+ * upstream/traversals/ReleaseManagement/artifacts/metadata-schemas/schemas/release-metadata-schema.yaml
+ *
+ * Always regenerates ALL metadata files - git diff shows what changed.
+ * No modes needed - idempotent regeneration.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// Paths
+const DATA_DIR = path.join(__dirname, '..', '..', '..', 'data');
+const MASTER_FILE = path.join(DATA_DIR, 'releases-master.yaml');
+const ARTIFACTS_DIR = path.join(DATA_DIR, 'release-artifacts');
+
+/**
+ * Load the master metadata file
+ * @returns {object} Master metadata with releases
+ */
+function loadMaster() {
+  if (!fs.existsSync(MASTER_FILE)) {
+    console.error(`Master file not found: ${MASTER_FILE}`);
+    process.exit(1);
+  }
+  return yaml.load(fs.readFileSync(MASTER_FILE, 'utf8'));
+}
+
+/**
+ * Convert master release entry to release-metadata schema format
+ * @param {object} release - Release from releases-master.yaml
+ * @returns {object} Release metadata conforming to upstream schema
+ */
+function toReleaseMetadata(release) {
+  // Use schema 2.0.0 property names only (clean break)
+  const apis = (release.apis || []).map(api => ({
+    api_name: api.api_name,
+    api_version: api.api_version,
+    api_title: api.api_title || api.api_name
+  }));
+
+  return {
+    repository: {
+      repository_name: release.repository,
+      release_tag: release.release_tag,
+      release_type: release.release_type,  // Use directly from master file
+      release_date: formatReleaseDate(release.release_date),
+      src_commit_sha: null  // Not available for backfill
+    },
+    apis: apis
+  };
+}
+
+/**
+ * Format release date to ISO 8601 UTC format
+ * @param {string} dateString - Date string from release
+ * @returns {string|null} Formatted date or null
+ */
+function formatReleaseDate(dateString) {
+  if (!dateString) return null;
+
+  try {
+    const date = new Date(dateString);
+    // Format: YYYY-MM-DDTHH:MM:SSZ
+    return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  } catch (e) {
+    return dateString;
+  }
+}
+
+/**
+ * Write release metadata files
+ * @param {object} metadata - Release metadata object
+ * @param {string} repo - Repository name
+ * @param {string} tag - Release tag
+ */
+function writeMetadataFiles(metadata, repo, tag) {
+  const dir = path.join(ARTIFACTS_DIR, repo, tag);
+
+  // Create directory structure
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Write YAML file
+  const yamlContent = yaml.dump(metadata, {
+    indent: 2,
+    lineWidth: -1,
+    noRefs: true,
+    quotingType: '"',
+    forceQuotes: false
+  });
+  fs.writeFileSync(path.join(dir, 'release-metadata.yaml'), yamlContent);
+
+  // Write JSON file
+  const jsonContent = JSON.stringify(metadata, null, 2);
+  fs.writeFileSync(path.join(dir, 'release-metadata.json'), jsonContent);
+}
+
+/**
+ * Process all releases
+ * @returns {object} Processing results
+ */
+function processReleases() {
+  const master = loadMaster();
+  const releases = master.releases || [];
+
+  const results = {
+    processed: 0,
+    errors: [],
+    files: []
+  };
+
+  console.error(`Processing ${releases.length} releases...`);
+
+  for (const release of releases) {
+    const repo = release.repository;
+    const tag = release.release_tag;
+
+    try {
+      const metadata = toReleaseMetadata(release);
+      writeMetadataFiles(metadata, repo, tag);
+
+      console.error(`Generated ${repo}/${tag}`);
+      results.processed++;
+      results.files.push(`${repo}/${tag}/release-metadata.yaml`);
+      results.files.push(`${repo}/${tag}/release-metadata.json`);
+    } catch (error) {
+      console.error(`Error processing ${repo}/${tag}: ${error.message}`);
+      results.errors.push({ repo, tag, error: error.message });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Main execution
+ */
+function main() {
+  const args = process.argv.slice(2);
+
+  // Check for help
+  if (args.includes('--help') || args.includes('-h')) {
+    console.error(`
+Usage: node generate-release-metadata.js
+
+Generates release-metadata.yaml and release-metadata.json files for ALL releases
+in releases-master.yaml. Always regenerates all files - git diff shows changes.
+
+Output directory: data/release-artifacts/{repo}/{tag}/
+`);
+    process.exit(0);
+  }
+
+  console.error('Release Metadata Generator');
+  console.error('');
+
+  const results = processReleases();
+
+  // Output summary
+  console.error('');
+  console.error('=== Summary ===');
+  console.error(`Processed: ${results.processed}`);
+  console.error(`Errors: ${results.errors.length}`);
+
+  if (results.errors.length > 0) {
+    console.error('\nErrors:');
+    results.errors.forEach(e => {
+      console.error(`  ${e.repo}/${e.tag}: ${e.error}`);
+    });
+  }
+
+  // Output JSON summary to stdout for workflow consumption
+  console.log(JSON.stringify({
+    processed: results.processed,
+    errors: results.errors.length,
+    files: results.files
+  }, null, 2));
+
+  // Exit with error if all releases failed
+  if (results.processed === 0 && results.errors.length > 0) {
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  toReleaseMetadata,
+  processReleases,
+  loadMaster,
+  formatReleaseDate
+};

--- a/workflows/release-collector/scripts/lib/enrichment.js
+++ b/workflows/release-collector/scripts/lib/enrichment.js
@@ -326,7 +326,8 @@ function createFlattenedAPIView(releases) {
         release_tag: release.release_tag,
         release_date: release.release_date,
         meta_release: release.meta_release,
-        github_url: release.github_url
+        github_url: release.github_url,
+        release_type: release.release_type
       });
     }
   }

--- a/workflows/release-collector/scripts/lib/enrichment.js
+++ b/workflows/release-collector/scripts/lib/enrichment.js
@@ -76,10 +76,10 @@ function findEnrichment(apiName, landscape) {
 function enrichAPI(api, landscape, currentMetaRelease = null) {
   const enrichment = findEnrichment(api.api_name, landscape);
 
-  // Determine API maturity based on version
+  // Determine API maturity based on api_version
   let maturity = 'initial';  // default
-  if (api.version && typeof api.version === 'string') {
-    if (api.version.match(/^0\./)) {
+  if (api.api_version && typeof api.api_version === 'string') {
+    if (api.api_version.match(/^0\./)) {
       maturity = 'initial';
     } else {
       maturity = 'stable';
@@ -94,7 +94,7 @@ function enrichAPI(api, landscape, currentMetaRelease = null) {
       portfolio_category: null,
       website_url: null,
       tooltip: null,
-      display_name: api.title || api.api_name,
+      display_name: api.api_title || api.api_name,
       published: true,  // Default to published if not specified
       canonical_name: api.api_name,
       first_release: 'Sandbox',  // Default for unknown APIs
@@ -121,7 +121,7 @@ function enrichAPI(api, landscape, currentMetaRelease = null) {
     portfolio_category: enrichment.category || null,
     website_url: enrichment.website_url || null,
     tooltip: enrichment.tooltip || null,
-    display_name: enrichment.display_name || api.title || api.api_name,
+    display_name: enrichment.display_name || api.api_title || api.api_name,
     published: enrichment.published !== false,  // Default to true
     canonical_name: enrichment.canonical_name || api.api_name,
     first_release: enrichment.first_release || 'Sandbox',
@@ -255,10 +255,10 @@ function generateEnrichedStatistics(releases) {
       }
 
       // Determine API maturity
-      if (api.version) {
-        if (api.version.includes('-rc')) {
+      if (api.api_version) {
+        if (api.api_version.includes('-rc')) {
           stats.api_maturity.rc++;
-        } else if (api.version.match(/^0\./)) {
+        } else if (api.api_version.match(/^0\./)) {
           stats.api_maturity.initial++;
         } else {
           stats.api_maturity.stable++;
@@ -267,8 +267,8 @@ function generateEnrichedStatistics(releases) {
         // Track latest version per canonical API
         const canonicalName = api.canonical_name || api.api_name;
         const currentLatest = stats.latest_versions.get(canonicalName);
-        if (!currentLatest || compareVersions(api.version, currentLatest) > 0) {
-          stats.latest_versions.set(canonicalName, api.version);
+        if (!currentLatest || compareVersions(api.api_version, currentLatest) > 0) {
+          stats.latest_versions.set(canonicalName, api.api_version);
         }
       }
 
@@ -286,10 +286,10 @@ function generateEnrichedStatistics(releases) {
   }
 
   // Calculate unique API maturity based on latest versions
-  for (const [canonicalName, version] of stats.latest_versions) {
-    if (version.includes('-rc')) {
+  for (const [canonicalName, latestVersion] of stats.latest_versions) {
+    if (latestVersion.includes('-rc')) {
       stats.unique_api_maturity.rc++;
-    } else if (version.match(/^0\./)) {
+    } else if (latestVersion.match(/^0\./)) {
       stats.unique_api_maturity.initial++;
     } else {
       stats.unique_api_maturity.stable++;

--- a/workflows/release-collector/scripts/update-master.js
+++ b/workflows/release-collector/scripts/update-master.js
@@ -42,12 +42,20 @@ function loadMaster() {
         last_updated: null,
         last_checked: null,
         workflow_version: "3.0.0",
-        schema_version: "1.0.0"
+        schema_version: "1.1.0"
       },
-      releases: []
+      releases: [],
+      repositories: []
     };
   }
-  return yaml.load(fs.readFileSync(MASTER_FILE, 'utf8'));
+  const master = yaml.load(fs.readFileSync(MASTER_FILE, 'utf8'));
+  // Ensure repositories array exists (migration from 1.0.0)
+  if (!master.repositories) {
+    master.repositories = [];
+  }
+  // Update schema version if needed
+  master.metadata.schema_version = "1.1.0";
+  return master;
 }
 
 /**
@@ -82,6 +90,86 @@ function findExistingRelease(releases, repository, releaseTag) {
 }
 
 /**
+ * Determine if a pre-release should be included
+ * A pre-release is excluded if there's a non-prerelease in the same cycle
+ */
+function shouldIncludePrerelease(prerelease, allReleases) {
+  const cycle = prerelease.release_tag.match(/^(r\d+)\./)?.[1];
+  if (!cycle) return true;
+
+  const hasPublicRelease = allReleases.some(r =>
+    r.repository === prerelease.repository &&
+    r.release_tag.startsWith(cycle + '.') &&
+    !r.is_prerelease
+  );
+
+  return !hasPublicRelease;
+}
+
+/**
+ * Determine release_type for non-prereleases
+ * - First non-prerelease in a cycle → public-release
+ * - Subsequent non-prereleases → maintenance-release
+ */
+function determineNonPrereleaseType(release, allReleases) {
+  const cycle = release.release_tag.match(/^(r\d+)\./)?.[1];
+  if (!cycle) return 'public-release';
+
+  // Get all non-prereleases in the same cycle for this repo, sorted by tag
+  const cycleReleases = allReleases
+    .filter(r =>
+      r.repository === release.repository &&
+      r.release_tag.startsWith(cycle + '.') &&
+      !r.is_prerelease
+    )
+    .sort((a, b) => {
+      const aMatch = a.release_tag.match(/r\d+\.(\d+)/);
+      const bMatch = b.release_tag.match(/r\d+\.(\d+)/);
+      return (aMatch ? parseInt(aMatch[1]) : 0) - (bMatch ? parseInt(bMatch[1]) : 0);
+    });
+
+  // First one in the cycle is public-release, rest are maintenance
+  if (cycleReleases.length > 0 && cycleReleases[0].release_tag === release.release_tag) {
+    return 'public-release';
+  }
+  return 'maintenance-release';
+}
+
+/**
+ * Compute repository release references
+ * - latest_public_release: Most recent public/maintenance release
+ * - newest_pre_release: Most recent pre-release if newer than latest public
+ */
+function computeRepoReleaseRefs(repoName, releases) {
+  const repoReleases = releases.filter(r => r.repository === repoName);
+
+  // Find latest public/maintenance release (by date)
+  const publicReleases = repoReleases
+    .filter(r => r.release_type === 'public-release' || r.release_type === 'maintenance-release')
+    .sort((a, b) => new Date(b.release_date) - new Date(a.release_date));
+  const latestPublic = publicReleases[0]?.release_tag || null;
+  const latestPublicDate = publicReleases[0]?.release_date || null;
+
+  // Find newest pre-release (only if newer than latest public)
+  const preReleases = repoReleases
+    .filter(r => r.release_type === 'pre-release-alpha' || r.release_type === 'pre-release-rc')
+    .sort((a, b) => new Date(b.release_date) - new Date(a.release_date));
+
+  let newestPreRelease = null;
+  if (preReleases.length > 0) {
+    const newestPre = preReleases[0];
+    if (!latestPublicDate || new Date(newestPre.release_date) > new Date(latestPublicDate)) {
+      newestPreRelease = newestPre.release_tag;
+    }
+  }
+
+  return {
+    latest_public_release: latestPublic,
+    newest_pre_release: newestPreRelease
+  };
+}
+
+/**
  * Update master metadata with new analysis results
  * Format corrections have already been applied by analyze-release.js
  */
@@ -92,9 +180,52 @@ function updateMaster(master, analysisResults, mode, mappings) {
   master.metadata.last_updated = timestamp;
   master.metadata.last_checked = timestamp;
 
-  // Process each analysis result
+  // First pass: add all releases to get complete picture for filtering
+  const tempReleases = [...master.releases];
+
   for (const result of analysisResults) {
+    const existingIndex = tempReleases.findIndex(r =>
+      r.repository === result.repository && r.release_tag === result.release_tag
+    );
+
+    const tempEntry = {
+      repository: result.repository,
+      release_tag: result.release_tag,
+      release_date: result.release_date,
+      is_prerelease: result.is_prerelease,
+      release_type: result.release_type  // Pre-populated for pre-releases, null for non-prereleases
+    };
+
+    if (existingIndex >= 0) {
+      tempReleases[existingIndex] = { ...tempReleases[existingIndex], ...tempEntry };
+    } else {
+      tempReleases.push(tempEntry);
+    }
+  }
+
+  // Second pass: process results with full context
+  for (const result of analysisResults) {
+    // Filter pre-releases that are superseded by a public release in same cycle
+    if (result.is_prerelease && !shouldIncludePrerelease(result, tempReleases)) {
+      console.log(`Filtered (superseded): ${result.repository} ${result.release_tag}`);
+      // Remove from master if it existed
+      const idx = master.releases.findIndex(r =>
+        r.repository === result.repository && r.release_tag === result.release_tag
+      );
+      if (idx >= 0) {
+        master.releases.splice(idx, 1);
+      }
+      continue;
+    }
+
     const metaRelease = getMetaRelease(result.repository, result.release_tag, mappings);
+
+    // Determine release_type
+    let releaseType = result.release_type;  // Use pre-populated type for pre-releases
+    if (!releaseType && !result.is_prerelease) {
+      // Determine public-release vs maintenance-release for non-prereleases
+      releaseType = determineNonPrereleaseType(result, tempReleases);
+    }
 
     // Build release entry (with format corrections already applied)
     const releaseEntry = {
@@ -103,6 +234,7 @@ function updateMaster(master, analysisResults, mode, mappings) {
       release_date: result.release_date,
       meta_release: metaRelease,
       github_url: result.github_url,
+      release_type: releaseType,
       apis: result.apis.map(api => ({
         api_name: api.api_name,        // Raw API name from server URL
         file_name: api.file_name,      // Raw filename for reference
@@ -118,11 +250,11 @@ function updateMaster(master, analysisResults, mode, mappings) {
     if (existingIndex >= 0) {
       // Update existing release
       master.releases[existingIndex] = releaseEntry;
-      console.log(`Updated: ${result.repository} ${result.release_tag}`);
+      console.log(`Updated: ${result.repository} ${result.release_tag} (${releaseType})`);
     } else {
       // Add new release
       master.releases.push(releaseEntry);
-      console.log(`Added: ${result.repository} ${result.release_tag}`);
+      console.log(`Added: ${result.repository} ${result.release_tag} (${releaseType})`);
     }
   }
 
@@ -147,6 +279,41 @@ function updateMaster(master, analysisResults, mode, mappings) {
 }
 
 /**
+ * Update repositories array with release references
+ */
+function updateRepositories(master, repositoriesInput) {
+  // Build map of existing repos
+  const repoMap = new Map();
+
+  // Add all repos from input
+  for (const repo of repositoriesInput) {
+    repoMap.set(repo.repository, {
+      repository: repo.repository,
+      github_url: repo.github_url
+    });
+  }
+
+  // Compute release references for each repo
+  for (const [repoName, repoData] of repoMap) {
+    const refs = computeRepoReleaseRefs(repoName, master.releases);
+    repoData.latest_public_release = refs.latest_public_release;
+    repoData.newest_pre_release = refs.newest_pre_release;
+  }
+
+  // Convert to sorted array
+  master.repositories = Array.from(repoMap.values())
+    .sort((a, b) => a.repository.localeCompare(b.repository));
+
+  console.log(`\nRepositories updated: ${master.repositories.length}`);
+  const withPublic = master.repositories.filter(r => r.latest_public_release).length;
+  const withPreOnly = master.repositories.filter(r => !r.latest_public_release && r.newest_pre_release).length;
+  const noReleases = master.repositories.filter(r => !r.latest_public_release && !r.newest_pre_release).length;
+  console.log(`  With public release: ${withPublic}`);
+  console.log(`  Pre-release only: ${withPreOnly}`);
+  console.log(`  No releases: ${noReleases}`);
+}
+
+/**
  * Main execution
  */
 async function main() {
@@ -155,6 +322,7 @@ async function main() {
   // Parse arguments
   let mode = 'incremental';
   let inputFile = null;
+  let reposFile = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--mode' && i + 1 < args.length) {
@@ -163,11 +331,14 @@ async function main() {
     } else if (args[i] === '--input' && i + 1 < args.length) {
       inputFile = args[i + 1];
       i++;
+    } else if (args[i] === '--repos' && i + 1 < args.length) {
+      reposFile = args[i + 1];
+      i++;
     }
   }
 
   if (!inputFile) {
-    console.error('Usage: node update-master.js --mode [incremental|full] --input <analysis-results.json>');
+    console.error('Usage: node update-master.js --mode [incremental|full] --input <analysis-results.json> [--repos <repositories.json>]');
     process.exit(1);
   }
 
@@ -191,6 +362,16 @@ async function main() {
 
     // Update master with new data
     const updatedMaster = updateMaster(master, analysisResults, mode, mappings);
+
+    // Update repositories if repos file provided
+    if (reposFile) {
+      if (!fs.existsSync(reposFile)) {
+        console.error(`Repos file not found: ${reposFile}`);
+        process.exit(1);
+      }
+      const reposData = JSON.parse(fs.readFileSync(reposFile, 'utf8'));
+      updateRepositories(updatedMaster, reposData.repositories || []);
+    }
 
     // Write updated master file
     const yamlContent = yaml.dump(updatedMaster, {
@@ -219,6 +400,17 @@ async function main() {
       console.log(`  ${mr}: ${stats.repositories.size} repositories, ${stats.apis} APIs`);
     }
 
+    // Summary by release_type
+    const typeSummary = {};
+    for (const release of updatedMaster.releases) {
+      const rt = release.release_type || 'unknown';
+      typeSummary[rt] = (typeSummary[rt] || 0) + 1;
+    }
+    console.log('\nSummary by release_type:');
+    for (const [rt, count] of Object.entries(typeSummary)) {
+      console.log(`  ${rt}: ${count}`);
+    }
+
   } catch (error) {
     console.error('Error:', error.message);
     process.exit(1);
@@ -234,5 +426,9 @@ module.exports = {
   loadMaster,
   loadMappings,
   updateMaster,
-  getMetaRelease
+  updateRepositories,
+  getMetaRelease,
+  shouldIncludePrerelease,
+  determineNonPrereleaseType,
+  computeRepoReleaseRefs
 };

--- a/workflows/release-collector/scripts/update-master.js
+++ b/workflows/release-collector/scripts/update-master.js
@@ -42,7 +42,7 @@ function loadMaster() {
         last_updated: null,
         last_checked: null,
         workflow_version: "3.0.0",
-        schema_version: "1.1.0"
+        schema_version: "2.0.0"
       },
       releases: [],
       repositories: []
@@ -54,7 +54,7 @@ function loadMaster() {
     master.repositories = [];
   }
   // Update schema version if needed
-  master.metadata.schema_version = "1.1.0";
+  master.metadata.schema_version = "2.0.0";
   return master;
 }
 
@@ -238,8 +238,8 @@ function updateMaster(master, analysisResults, mode, mappings) {
       apis: result.apis.map(api => ({
         api_name: api.api_name,        // Raw API name from server URL
         file_name: api.file_name,      // Raw filename for reference
-        version: api.version,
-        title: api.title,
+        api_version: api.api_version,
+        api_title: api.api_title,
         commonalities: api.commonalities
       }))
     };

--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -286,12 +286,41 @@
     }
 
     /* Special row types */
-    .unpublished-row {
-      background-color: rgba(212, 167, 44, 0.1);
+    .prerelease-row {
+      background-color: rgba(139, 92, 246, 0.08);
     }
 
     .sandbox-row {
       background-color: rgba(251, 146, 60, 0.1);
+    }
+
+    /* Release type filters */
+    .release-type-filters {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 4px 12px;
+      background: var(--bg-tertiary);
+      border-radius: 6px;
+      border: 1px solid var(--border-color);
+    }
+
+    .release-type-filters .filter-label {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-secondary);
+    }
+
+    .release-type-filters label {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+
+    .release-type-filters input[type="checkbox"] {
+      margin: 0;
     }
 
     /* Badges */
@@ -410,12 +439,20 @@
       margin-right: 6px;
     }
 
-    .status-published {
+    .status-public {
       background: var(--success-color);
     }
 
-    .status-unpublished {
-      background: var(--danger-color);
+    .status-maintenance {
+      background: #3b82f6;
+    }
+
+    .status-prerelease-rc {
+      background: #8b5cf6;
+    }
+
+    .status-prerelease-alpha {
+      background: #f59e0b;
     }
 
     .status-sandbox {
@@ -579,10 +616,13 @@
 
         <button onclick="exportDebugData()">Export Debug Data</button>
 
-        <label>
-          <input type="checkbox" id="show-unpublished" checked onchange="applyFilters()">
-          Show Unpublished
-        </label>
+        <div class="release-type-filters">
+          <span class="filter-label">Release Types:</span>
+          <label><input type="checkbox" id="show-alpha" checked onchange="applyFilters()"> Alpha</label>
+          <label><input type="checkbox" id="show-rc" checked onchange="applyFilters()"> RC</label>
+          <label><input type="checkbox" id="show-public" checked onchange="applyFilters()"> Public</label>
+          <label><input type="checkbox" id="show-maintenance" checked onchange="applyFilters()"> Maint</label>
+        </div>
 
         <label>
           <input type="checkbox" id="showOnlyLatestPatches" checked onchange="applyFilters()">
@@ -625,14 +665,6 @@
               <option value="None (Sandbox)">Sandbox</option>
             </select>
           </div>
-          <div class="filter-group">
-            <label for="filterPublished">Published:</label>
-            <select id="filterPublished" onchange="applyFilters()">
-              <option value="">All</option>
-              <option value="yes">Yes</option>
-              <option value="no">No</option>
-            </select>
-          </div>
           <button class="clear-filters-btn" onclick="clearAllFilters()">Clear Filters</button>
         </div>
       </div>
@@ -653,7 +685,7 @@
               <th onclick="sortTable(3)">Release Tag <span class="sort-arrow"></span></th>
               <th onclick="sortTable(4)">Meta-Release <span class="sort-arrow"></span></th>
               <th onclick="sortTable(5)">Maturity <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(6)">Published <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(6)">Type <span class="sort-arrow"></span></th>
               <th onclick="sortTable(7)">Category <span class="sort-arrow"></span></th>
               <th onclick="sortTable(8)">First Release <span class="sort-arrow"></span></th>
               <th>Debug</th>
@@ -803,15 +835,16 @@
       const generated = ViewerLib.formatDate(metadata.generated);
 
       const totalAPIs = data.apis.length;
-      const publishedCount = data.apis.filter(a => a.published).length;
-      const unpublishedCount = totalAPIs - publishedCount;
+      const alphaCount = data.apis.filter(a => a.release_type === 'pre-release-alpha').length;
+      const rcCount = data.apis.filter(a => a.release_type === 'pre-release-rc').length;
+      const publicCount = data.apis.filter(a => a.release_type === 'public-release' || !a.release_type).length;
+      const maintenanceCount = data.apis.filter(a => a.release_type === 'maintenance-release').length;
       const sandboxCount = data.apis.filter(a => a.meta_release === 'None (Sandbox)').length;
 
       footerDiv.innerHTML = `
         Report generated: ${generated} |
-        Total API versions: ${totalAPIs} |
-        Published: ${publishedCount} |
-        Unpublished: ${unpublishedCount} |
+        Total: ${totalAPIs} |
+        Alpha: ${alphaCount} | RC: ${rcCount} | Public: ${publicCount} | Maint: ${maintenanceCount} |
         Sandbox: ${sandboxCount}
       `;
 
@@ -909,8 +942,13 @@
       const searchFilter = document.getElementById('filterApiName').value.toLowerCase();
       const maturityFilter = document.getElementById('filterMaturity').value.toLowerCase();
       const metaReleaseFilter = document.getElementById('filterMetaRelease').value;
-      const publishedFilter = document.getElementById('filterPublished').value;
-      const showUnpublished = document.getElementById('show-unpublished').checked;
+
+      // Release type filters
+      const showAlpha = document.getElementById('show-alpha').checked;
+      const showRc = document.getElementById('show-rc').checked;
+      const showPublic = document.getElementById('show-public').checked;
+      const showMaintenance = document.getElementById('show-maintenance').checked;
+
       showOnlyLatestPatches = document.getElementById('showOnlyLatestPatches').checked;
 
       filteredData = currentData.apis.filter(api => {
@@ -939,17 +977,12 @@
           return false;
         }
 
-        // Published filter
-        if (publishedFilter) {
-          const isPublished = api.published;
-          if (publishedFilter === 'yes' && !isPublished) return false;
-          if (publishedFilter === 'no' && isPublished) return false;
-        }
-
-        // Show unpublished checkbox
-        if (!showUnpublished && !api.published) {
-          return false;
-        }
+        // Release type filter
+        const releaseType = api.release_type || 'public-release';  // Default for legacy data
+        if (releaseType === 'pre-release-alpha' && !showAlpha) return false;
+        if (releaseType === 'pre-release-rc' && !showRc) return false;
+        if (releaseType === 'public-release' && !showPublic) return false;
+        if (releaseType === 'maintenance-release' && !showMaintenance) return false;
 
         return true;
       });
@@ -969,8 +1002,11 @@
       document.getElementById('filterApiName').value = '';
       document.getElementById('filterMaturity').value = '';
       document.getElementById('filterMetaRelease').value = '';
-      document.getElementById('filterPublished').value = '';
-      document.getElementById('show-unpublished').checked = true;
+      // Reset release type checkboxes
+      document.getElementById('show-alpha').checked = true;
+      document.getElementById('show-rc').checked = true;
+      document.getElementById('show-public').checked = true;
+      document.getElementById('show-maintenance').checked = true;
       selectedCategories = [];
       updatePillStates();
       applyFilters();
@@ -1024,17 +1060,25 @@
         const row = document.createElement('tr');
 
         // Add row classes for visual indicators
-        if (!api.published) {
-          row.classList.add('unpublished-row');
+        const releaseType = api.release_type || 'public-release';
+        if (releaseType.startsWith('pre-release')) {
+          row.classList.add('prerelease-row');
         }
         if (api.meta_release === 'None (Sandbox)') {
           row.classList.add('sandbox-row');
         }
 
-        // Status indicator
-        const statusClass = !api.published ? 'status-unpublished' :
+        // Status indicator based on release type
+        const statusClass = releaseType === 'pre-release-alpha' ? 'status-prerelease-alpha' :
+          releaseType === 'pre-release-rc' ? 'status-prerelease-rc' :
+          releaseType === 'maintenance-release' ? 'status-maintenance' :
           api.meta_release === 'None (Sandbox)' ? 'status-sandbox' :
-            'status-published';
+            'status-public';
+
+        // Release type display
+        const releaseTypeLabel = releaseType === 'pre-release-alpha' ? 'Alpha' :
+          releaseType === 'pre-release-rc' ? 'RC' :
+          releaseType === 'maintenance-release' ? 'Maint' : 'Public';
 
         row.innerHTML = `
           <td><span class="status-indicator ${statusClass}"></span>${api.api_name}</td>
@@ -1043,7 +1087,7 @@
           <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
           <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
           <td>${ViewerLib.renderMaturityBadge(api.maturity)}</td>
-          <td>${api.published ? '✓' : '✗'}</td>
+          <td>${releaseTypeLabel}</td>
           <td>${api.portfolio_category || '<em>Missing</em>'}</td>
           <td>${api.first_release || '-'}</td>
           <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)}, ${JSON.stringify(api.version)}, ${JSON.stringify(api.release_tag)})'>🔍</button></td>
@@ -1084,7 +1128,7 @@
                 <th>Release</th>
                 <th>Meta-Release</th>
                 <th>Maturity</th>
-                <th>Published</th>
+                <th>Type</th>
                 <th>Category</th>
               </tr>
             </thead>
@@ -1113,9 +1157,14 @@
         // API rows for this repository
         repo.apis.forEach(api => {
           const rowClasses = [];
-          if (!api.published) rowClasses.push('unpublished-row');
+          const releaseType = api.release_type || 'public-release';
+          if (releaseType.startsWith('pre-release')) rowClasses.push('prerelease-row');
           if (api.meta_release === 'None (Sandbox)') rowClasses.push('sandbox-row');
           rowClasses.push('repo-row');
+
+          const releaseTypeLabel = releaseType === 'pre-release-alpha' ? 'Alpha' :
+            releaseType === 'pre-release-rc' ? 'RC' :
+            releaseType === 'maintenance-release' ? 'Maint' : 'Public';
 
           tableHtml += `
             <tr class="${rowClasses.join(' ')}">
@@ -1124,7 +1173,7 @@
               <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
               <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
               <td>${ViewerLib.renderMaturityBadge(api.maturity)}</td>
-              <td>${api.published ? '✓' : '✗'}</td>
+              <td>${releaseTypeLabel}</td>
               <td>${api.portfolio_category || '-'}</td>
             </tr>
           `;
@@ -1213,8 +1262,9 @@
           // Version column
           result = ViewerLib.compareVersions(aValue, bValue);
         } else if (columnIndex === 6) {
-          // Published column (✓/✗)
-          result = (aValue === '✓' ? 1 : 0) - (bValue === '✓' ? 1 : 0);
+          // Type column (Alpha/RC/Public/Maint)
+          const typeOrder = { 'Alpha': 0, 'RC': 1, 'Public': 2, 'Maint': 3 };
+          result = (typeOrder[aValue] ?? 4) - (typeOrder[bValue] ?? 4);
         } else {
           result = aValue.localeCompare(bValue);
         }

--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -742,8 +742,8 @@
             release.apis.forEach(api => {
               flatApis.push({
                 api_name: api.api_name,
-                title: api.title || api.display_name || api.api_name,
-                version: api.version,
+                api_title: api.api_title || api.display_name || api.api_name,
+                api_version: api.api_version,
                 maturity: api.maturity,
                 repository: release.repository,
                 release_tag: release.release_tag,
@@ -962,14 +962,14 @@
         // Search filter
         if (searchFilter &&
           !api.api_name.toLowerCase().includes(searchFilter) &&
-          !api.title.toLowerCase().includes(searchFilter) &&
+          !api.api_title.toLowerCase().includes(searchFilter) &&
           !api.repository.toLowerCase().includes(searchFilter)) {
           return false;
         }
 
-        // API Status filter (computed from version)
+        // API Status filter (computed from api_version)
         if (apiStatusFilter) {
-          const apiStatus = ViewerLib.getApiStatus(api.version);
+          const apiStatus = ViewerLib.getApiStatus(api.api_version);
           if (apiStatus !== apiStatusFilter) return false;
         }
 
@@ -1081,10 +1081,10 @@
           releaseType === 'pre-release-rc' ? 'RC' :
           releaseType === 'maintenance-release' ? 'Maint' : 'Public';
 
-        const apiStatus = ViewerLib.getApiStatus(api.version);
+        const apiStatus = ViewerLib.getApiStatus(api.api_version);
         row.innerHTML = `
           <td><span class="status-indicator ${statusClass}"></span>${api.api_name}</td>
-          <td>${api.version}</td>
+          <td>${api.api_version}</td>
           <td>${ViewerLib.renderApiStatusBadge(apiStatus)}</td>
           <td>${api.portfolio_category || '<em>Missing</em>'}</td>
           <td><a href="${api.github_url.replace(/\/releases\/tag\/.*$/, '')}" target="_blank">${api.repository}</a></td>
@@ -1092,7 +1092,7 @@
           <td>${releaseTypeLabel}</td>
           <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
           <td>${api.first_release || '-'}</td>
-          <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)}, ${JSON.stringify(api.version)}, ${JSON.stringify(api.release_tag)})'>🔍</button></td>
+          <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)}, ${JSON.stringify(api.api_version)}, ${JSON.stringify(api.release_tag)})'>🔍</button></td>
         `;
 
         tbody.appendChild(row);
@@ -1168,11 +1168,11 @@
             releaseType === 'pre-release-rc' ? 'RC' :
             releaseType === 'maintenance-release' ? 'Maint' : 'Public';
 
-          const apiStatus = ViewerLib.getApiStatus(api.version);
+          const apiStatus = ViewerLib.getApiStatus(api.api_version);
           tableHtml += `
             <tr class="${rowClasses.join(' ')}">
               <td>${api.api_name}</td>
-              <td>${api.version}</td>
+              <td>${api.api_version}</td>
               <td>${ViewerLib.renderApiStatusBadge(apiStatus)}</td>
               <td>${api.portfolio_category || '-'}</td>
               <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
@@ -1195,10 +1195,10 @@
     /**
      * Show debug modal for specific API
      */
-    function showDebug(apiName, version, releaseTag) {
+    function showDebug(apiName, apiVersion, releaseTag) {
       const api = filteredData.find(a =>
         a.api_name === apiName &&
-        a.version === version &&
+        a.api_version === apiVersion &&
         a.release_tag === releaseTag
       );
       if (!api) return;

--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -645,14 +645,13 @@
             <input type="text" id="filterApiName" placeholder="API or repository..." onkeyup="applyFilters()">
           </div>
           <div class="filter-group">
-            <label for="filterMaturity">Maturity:</label>
-            <select id="filterMaturity" onchange="applyFilters()">
+            <label for="filterApiStatus">API Status:</label>
+            <select id="filterApiStatus" onchange="applyFilters()">
               <option value="">All</option>
+              <option value="alpha">Alpha</option>
+              <option value="rc">RC</option>
               <option value="initial">Initial</option>
               <option value="stable">Stable</option>
-              <option value="rc">RC</option>
-              <option value="alpha">Alpha</option>
-              <option value="beta">Beta</option>
             </select>
           </div>
           <div class="filter-group">
@@ -681,12 +680,12 @@
             <tr>
               <th onclick="sortTable(0)">API <span class="sort-arrow"></span></th>
               <th onclick="sortTable(1)">Version <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(2)">Repository <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(3)">Release Tag <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(4)">Meta-Release <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(5)">Maturity <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(6)">Type <span class="sort-arrow"></span></th>
-              <th onclick="sortTable(7)">Category <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(2)">API Status <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(3)">Category <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(4)">Repository <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(5)">Release Tag <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(6)">Release Type <span class="sort-arrow"></span></th>
+              <th onclick="sortTable(7)">Meta-Release <span class="sort-arrow"></span></th>
               <th onclick="sortTable(8)">First Release <span class="sort-arrow"></span></th>
               <th>Debug</th>
             </tr>
@@ -941,7 +940,7 @@
       if (!currentData) return;
 
       const searchFilter = document.getElementById('filterApiName').value.toLowerCase();
-      const maturityFilter = document.getElementById('filterMaturity').value.toLowerCase();
+      const apiStatusFilter = document.getElementById('filterApiStatus').value.toLowerCase();
       const metaReleaseFilter = document.getElementById('filterMetaRelease').value;
 
       // Release type filters
@@ -968,9 +967,10 @@
           return false;
         }
 
-        // Maturity filter
-        if (maturityFilter && api.maturity.toLowerCase() !== maturityFilter) {
-          return false;
+        // API Status filter (computed from version)
+        if (apiStatusFilter) {
+          const apiStatus = ViewerLib.getApiStatus(api.version);
+          if (apiStatus !== apiStatusFilter) return false;
         }
 
         // Meta-release filter
@@ -1001,7 +1001,7 @@
      */
     function clearAllFilters() {
       document.getElementById('filterApiName').value = '';
-      document.getElementById('filterMaturity').value = '';
+      document.getElementById('filterApiStatus').value = '';
       document.getElementById('filterMetaRelease').value = '';
       // Reset release type checkboxes
       document.getElementById('show-alpha').checked = true;
@@ -1081,15 +1081,16 @@
           releaseType === 'pre-release-rc' ? 'RC' :
           releaseType === 'maintenance-release' ? 'Maint' : 'Public';
 
+        const apiStatus = ViewerLib.getApiStatus(api.version);
         row.innerHTML = `
           <td><span class="status-indicator ${statusClass}"></span>${api.api_name}</td>
           <td>${api.version}</td>
+          <td>${ViewerLib.renderApiStatusBadge(apiStatus)}</td>
+          <td>${api.portfolio_category || '<em>Missing</em>'}</td>
           <td><a href="${api.github_url.replace(/\/releases\/tag\/.*$/, '')}" target="_blank">${api.repository}</a></td>
           <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
-          <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
-          <td>${ViewerLib.renderMaturityBadge(api.maturity)}</td>
           <td>${releaseTypeLabel}</td>
-          <td>${api.portfolio_category || '<em>Missing</em>'}</td>
+          <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
           <td>${api.first_release || '-'}</td>
           <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)}, ${JSON.stringify(api.version)}, ${JSON.stringify(api.release_tag)})'>🔍</button></td>
         `;
@@ -1126,11 +1127,11 @@
               <tr>
                 <th>API</th>
                 <th>Version</th>
-                <th>Release</th>
-                <th>Meta-Release</th>
-                <th>Maturity</th>
-                <th>Type</th>
+                <th>API Status</th>
                 <th>Category</th>
+                <th>Release</th>
+                <th>Release Type</th>
+                <th>Meta-Release</th>
               </tr>
             </thead>
             <tbody>
@@ -1167,15 +1168,16 @@
             releaseType === 'pre-release-rc' ? 'RC' :
             releaseType === 'maintenance-release' ? 'Maint' : 'Public';
 
+          const apiStatus = ViewerLib.getApiStatus(api.version);
           tableHtml += `
             <tr class="${rowClasses.join(' ')}">
               <td>${api.api_name}</td>
               <td>${api.version}</td>
-              <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
-              <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
-              <td>${ViewerLib.renderMaturityBadge(api.maturity)}</td>
-              <td>${releaseTypeLabel}</td>
+              <td>${ViewerLib.renderApiStatusBadge(apiStatus)}</td>
               <td>${api.portfolio_category || '-'}</td>
+              <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
+              <td>${releaseTypeLabel}</td>
+              <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
             </tr>
           `;
         });
@@ -1262,8 +1264,12 @@
         if (columnIndex === 1) {
           // Version column
           result = ViewerLib.compareVersions(aValue, bValue);
+        } else if (columnIndex === 2) {
+          // API Status column (Alpha → RC → Initial → Stable)
+          const statusOrder = { 'Alpha': 0, 'RC': 1, 'Initial': 2, 'Stable': 3 };
+          result = (statusOrder[aValue] ?? 4) - (statusOrder[bValue] ?? 4);
         } else if (columnIndex === 6) {
-          // Type column (Alpha/RC/Public/Maint)
+          // Release Type column (Alpha/RC/Public/Maint)
           const typeOrder = { 'Alpha': 0, 'RC': 1, 'Public': 2, 'Maint': 3 };
           result = (typeOrder[aValue] ?? 4) - (typeOrder[bValue] ?? 4);
         } else {

--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -751,6 +751,7 @@
                 release_date: release.release_date,
                 meta_release: release.meta_release,
                 github_url: release.github_url,
+                release_type: release.release_type,
                 portfolio_category: api.portfolio_category,
                 website_url: api.website_url,
                 tooltip: api.tooltip,

--- a/workflows/release-collector/templates/meta-release-template.html
+++ b/workflows/release-collector/templates/meta-release-template.html
@@ -147,6 +147,7 @@
                 release_tag: release.release_tag,
                 release_date: release.release_date,
                 github_url: release.github_url,
+                release_type: release.release_type,
 
                 // Enrichment fields
                 portfolio_category: api.portfolio_category,

--- a/workflows/release-collector/templates/meta-release-template.html
+++ b/workflows/release-collector/templates/meta-release-template.html
@@ -138,8 +138,8 @@
               flatApis.push({
                 // API info
                 api_name: api.api_name,
-                title: api.title || api.display_name || api.api_name,
-                version: api.version,
+                api_title: api.api_title || api.display_name || api.api_name,
+                api_version: api.api_version,
                 maturity: api.maturity,
 
                 // Repository info from release
@@ -238,7 +238,7 @@
      * Populate version dropdown
      */
     function populateVersionDropdown() {
-      const versions = ViewerLib.getUniqueValues(currentData.apis, 'version');
+      const versions = ViewerLib.getUniqueValues(currentData.apis, 'api_version');
       const dropdown = document.getElementById('filterVersion');
 
       // Keep "All" option and add versions
@@ -360,7 +360,7 @@
         const maturityCell = `<span class="badge badge-${api.maturity}">${api.maturity.charAt(0).toUpperCase() + api.maturity.slice(1)}</span>`;
 
         // Version cell
-        const versionCell = api.version || '-';
+        const versionCell = api.api_version || '-';
 
         // Release cell with link
         const releaseCell = `<a href="${api.github_url}" target="_blank" rel="noopener">${api.release_tag}</a>`;
@@ -443,18 +443,18 @@
         }
 
         // Exact version filter (from dropdown)
-        if (versionFilter && api.version !== versionFilter) {
+        if (versionFilter && api.api_version !== versionFilter) {
           return false;
         }
 
         // Version range filters
-        if (versionMinFilter && api.version) {
-          if (ViewerLib.compareVersions(api.version, versionMinFilter) < 0) {
+        if (versionMinFilter && api.api_version) {
+          if (ViewerLib.compareVersions(api.api_version, versionMinFilter) < 0) {
             return false;
           }
         }
-        if (versionMaxFilter && api.version) {
-          if (ViewerLib.compareVersions(api.version, versionMaxFilter) > 0) {
+        if (versionMaxFilter && api.api_version) {
+          if (ViewerLib.compareVersions(api.api_version, versionMaxFilter) > 0) {
             return false;
           }
         }

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -562,7 +562,13 @@
         apis: flatApis
       };
 
-      filteredData = currentData.apis;
+      // Filter out alpha pre-releases (keep rc and public/maintenance)
+      filteredData = currentData.apis.filter(api =>
+        !api.release_type || api.release_type !== 'pre-release-alpha'
+      );
+
+      // Also update currentData.apis to exclude alpha for counts
+      currentData.apis = filteredData;
 
       displayData(currentData);
     }

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -432,6 +432,7 @@
                 release_date: release.release_date,
                 meta_release: release.meta_release,
                 github_url: release.github_url,
+                release_type: release.release_type,
 
                 // Enrichment fields
                 portfolio_category: api.portfolio_category,

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -422,8 +422,8 @@
               flatApis.push({
                 // API info
                 api_name: api.api_name,
-                title: api.title || api.display_name || api.api_name,
-                version: api.version,
+                api_title: api.api_title || api.display_name || api.api_name,
+                api_version: api.api_version,
                 maturity: api.maturity,
 
                 // Repository info from release
@@ -526,7 +526,7 @@
         // Create row data with version for each meta-release
         const row = {
           api_name: apiName,
-          title: latestAPI.display_name || latestAPI.title,
+          api_title: latestAPI.display_name || latestAPI.api_title,
           category: firstAPI.portfolio_category || '-',
           website_url: firstAPI.website_url,
           first_release: firstAPI.first_release,
@@ -537,11 +537,11 @@
 
         metaVersions.forEach(v => {
           if (v.meta_release === 'Fall24') {
-            row.fall24 = { version: v.version, maturity: v.maturity, isNew: v.isNew };
+            row.fall24 = { api_version: v.api_version, maturity: v.maturity, isNew: v.isNew };
           } else if (v.meta_release === 'Spring25') {
-            row.spring25 = { version: v.version, maturity: v.maturity, isNew: v.isNew };
+            row.spring25 = { api_version: v.api_version, maturity: v.maturity, isNew: v.isNew };
           } else if (v.meta_release === 'Fall25') {
-            row.fall25 = { version: v.version, maturity: v.maturity, isNew: v.isNew };
+            row.fall25 = { api_version: v.api_version, maturity: v.maturity, isNew: v.isNew };
           }
         });
 
@@ -706,7 +706,7 @@
         // Search filter (API name or repository)
         if (searchFilter &&
           !api.api_name.toLowerCase().includes(searchFilter) &&
-          !api.title.toLowerCase().includes(searchFilter) &&
+          !api.api_title.toLowerCase().includes(searchFilter) &&
           !api.repository.toLowerCase().includes(searchFilter)) {
           return false;
         }
@@ -799,7 +799,7 @@
         fall24Cell.className = 'release-cell';
         if (row.fall24) {
           fall24Cell.innerHTML = `
-            <div class="version-badge">${row.fall24.version}</div>
+            <div class="version-badge">${row.fall24.api_version}</div>
             ${ViewerLib.renderMaturityBadge(row.fall24.maturity)}
           `;
         } else {
@@ -812,7 +812,7 @@
         spring25Cell.className = 'release-cell';
         if (row.spring25) {
           spring25Cell.innerHTML = `
-            <div class="version-badge">${row.spring25.version}</div>
+            <div class="version-badge">${row.spring25.api_version}</div>
             ${ViewerLib.renderMaturityBadge(row.spring25.maturity)}
           `;
         } else {
@@ -825,7 +825,7 @@
         fall25Cell.className = 'release-cell';
         if (row.fall25) {
           fall25Cell.innerHTML = `
-            <div class="version-badge">${row.fall25.version}</div>
+            <div class="version-badge">${row.fall25.api_version}</div>
             ${ViewerLib.renderMaturityBadge(row.fall25.maturity)}
           `;
         } else {
@@ -899,7 +899,7 @@
           item.innerHTML = `
             <div>
               <div class="release-label">${isSandbox ? 'Sandbox' : version.meta_release}</div>
-              <div class="release-version">${version.version}</div>
+              <div class="release-version">${version.api_version}</div>
               ${ViewerLib.renderMaturityBadge(version.maturity)}
             </div>
           `;
@@ -968,7 +968,7 @@
           const releaseInfo = versions.map(v => {
             const isSandbox = v.meta_release === SANDBOX_RELEASE;
             const label = isSandbox ? 'Sandbox' : v.meta_release;
-            return `${label}: ${v.version}`;
+            return `${label}: ${v.api_version}`;
           }).join(' → ');
 
           apiItem.innerHTML = `

--- a/workflows/release-collector/templates/viewer-lib.js
+++ b/workflows/release-collector/templates/viewer-lib.js
@@ -63,7 +63,7 @@ const ViewerLib = {
 
     apis.forEach(api => {
       const apiKey = api.canonical_name || api.api_name;
-      const parsedVersion = this.parseVersion(api.version);
+      const parsedVersion = this.parseVersion(api.api_version);
 
       if (!parsedVersion) {
         // Keep APIs without valid versions
@@ -95,7 +95,7 @@ const ViewerLib = {
 
       // Sort by patch version (descending), then by date (descending)
       versions.sort((a, b) => {
-        const versionCompare = this.compareVersions(b.version, a.version);
+        const versionCompare = this.compareVersions(b.api_version, a.api_version);
         if (versionCompare !== 0) {
           return versionCompare;
         }
@@ -157,10 +157,10 @@ const ViewerLib = {
       }
 
       // Version range filters
-      if (criteria.versionMin && this.compareVersions(api.version, criteria.versionMin) < 0) {
+      if (criteria.versionMin && this.compareVersions(api.api_version, criteria.versionMin) < 0) {
         return false;
       }
-      if (criteria.versionMax && this.compareVersions(api.version, criteria.versionMax) > 0) {
+      if (criteria.versionMax && this.compareVersions(api.api_version, criteria.versionMax) > 0) {
         return false;
       }
 
@@ -180,7 +180,7 @@ const ViewerLib = {
     const lowerQuery = query.toLowerCase();
     return apis.filter(api =>
       api.api_name.toLowerCase().includes(lowerQuery) ||
-      (api.title && api.title.toLowerCase().includes(lowerQuery)) ||
+      (api.api_title && api.api_title.toLowerCase().includes(lowerQuery)) ||
       (api.portfolio_category && api.portfolio_category.toLowerCase().includes(lowerQuery)) ||
       (api.repository && api.repository.toLowerCase().includes(lowerQuery))
     );
@@ -199,7 +199,7 @@ const ViewerLib = {
       let bVal = b[field];
 
       // Handle version fields specially
-      if (field === 'version') {
+      if (field === 'api_version') {
         return this.compareVersions(aVal, bVal);
       }
 
@@ -298,11 +298,11 @@ const ViewerLib = {
    * @param {string} filename - Output filename
    */
   exportToCSV: function (apis, filename = 'camara-apis.csv') {
-    const headers = ['API Name', 'Title', 'Version', 'Category', 'Maturity', 'Repository', 'New', 'Release Tag'];
+    const headers = ['API Name', 'API Title', 'API Version', 'Category', 'Maturity', 'Repository', 'New', 'Release Tag'];
     const rows = apis.map(api => [
       api.api_name || '',
-      api.title || '',
-      api.version || '',
+      api.api_title || '',
+      api.api_version || '',
       api.portfolio_category || '',
       api.maturity || '',
       api.repository || '',

--- a/workflows/release-collector/templates/viewer-lib.js
+++ b/workflows/release-collector/templates/viewer-lib.js
@@ -320,7 +320,22 @@ const ViewerLib = {
   // Theme Toggling Logic
   // Theme Toggling Logic (3-State: Auto -> Light -> Dark)
   initThemeToggle: function (scope = 'default') {
-    const themeToggleBtn = document.getElementById('theme-toggle');
+    let themeToggleBtn = document.getElementById('theme-toggle');
+
+    // In iframe: inject toggle into footer (header is hidden in iframe)
+    if (this.isInIframe()) {
+      const footerMetadata = document.getElementById('footer-metadata');
+      if (footerMetadata) {
+        const footerToggle = document.createElement('button');
+        footerToggle.id = 'theme-toggle-footer';
+        footerToggle.className = 'theme-toggle-btn theme-toggle-footer';
+        footerToggle.setAttribute('aria-label', 'Toggle Dark Mode');
+        footerToggle.innerHTML = '<span class="theme-icon">🌗</span>';
+        footerMetadata.appendChild(footerToggle);
+        themeToggleBtn = footerToggle;
+      }
+    }
+
     if (!themeToggleBtn) return;
 
     const storageKey = `camara-theme-${scope}`;

--- a/workflows/release-collector/templates/viewer-lib.js
+++ b/workflows/release-collector/templates/viewer-lib.js
@@ -239,7 +239,37 @@ const ViewerLib = {
   },
 
   /**
-   * Render maturity badge HTML
+   * Compute API status from version string
+   * Status progression: alpha -> rc -> public (initial or stable)
+   * @param {string} version - API version string (e.g., "0.5.0-alpha.1", "1.0.0-rc.2", "1.0.0")
+   * @returns {string} API status: 'alpha', 'rc', 'initial', 'stable'
+   */
+  getApiStatus: function (version) {
+    if (!version) return 'unknown';
+    if (version.includes('-alpha.')) return 'alpha';
+    if (version.includes('-rc.')) return 'rc';
+    // Public: check initial (0.x) vs stable (1.x+)
+    if (version.match(/^0\./)) return 'initial';
+    return 'stable';
+  },
+
+  /**
+   * Render API status badge HTML
+   * @param {string} status - API status from getApiStatus()
+   * @returns {string} HTML string
+   */
+  renderApiStatusBadge: function (status) {
+    const badges = {
+      'stable': '<span class="badge badge-stable">Stable</span>',
+      'initial': '<span class="badge badge-initial">Initial</span>',
+      'rc': '<span class="badge badge-rc">RC</span>',
+      'alpha': '<span class="badge badge-alpha">Alpha</span>'
+    };
+    return badges[status] || `<span class="badge badge-unknown">${status}</span>`;
+  },
+
+  /**
+   * Render maturity badge HTML (deprecated - use renderApiStatusBadge)
    * @param {string} maturity - Maturity level
    * @returns {string} HTML string
    */
@@ -248,8 +278,7 @@ const ViewerLib = {
       'stable': '<span class="badge badge-stable">Stable</span>',
       'initial': '<span class="badge badge-initial">Initial</span>',
       'rc': '<span class="badge badge-rc">RC</span>',
-      'alpha': '<span class="badge badge-alpha">Alpha</span>',
-      'beta': '<span class="badge badge-beta">Beta</span>'
+      'alpha': '<span class="badge badge-alpha">Alpha</span>'
     };
     return badges[maturity] || `<span class="badge badge-unknown">${maturity}</span>`;
   },

--- a/workflows/release-collector/templates/viewer-styles.css
+++ b/workflows/release-collector/templates/viewer-styles.css
@@ -753,6 +753,21 @@ td:nth-child(7) {
   line-height: 1;
 }
 
+/* Footer theme toggle (for iframe context where header is hidden) */
+.theme-toggle-footer {
+  display: inline-flex;
+  margin-left: 12px;
+  background: var(--bg-container);
+  border: 1px solid var(--border-light);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.theme-toggle-footer:hover {
+  background: var(--bg-table-row-hover);
+  transform: scale(1.05);
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   body:not(.in-iframe) {


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Extends `releases-master.yaml` to track pre-releases and all API repositories with quick-reference release pointers. This enables visibility into repository release status including pre-release activity.

This is also a prerequisite for:
- camaraproject/project-administration#92
- The upcoming roll-out campaign for `release-plan.yaml`

**Schema Changes (v1.0.0 → v1.1.0, backward compatible):**
- Added `release_type` enum to releases: `pre-release-alpha`, `pre-release-rc`, `public-release`, `maintenance-release`
- Added `repositories` array with fields: `repository`, `github_url`, `latest_public_release`, `newest_pre_release`
- Updated schema_version to 1.1.0

**Collection Logic:**
- `detect-releases.js`: Include pre-releases from GitHub API, add `is_prerelease` flag, filter invalid r0.X tags
- `analyze-release.js`: Determine `release_type` from API version suffixes (`-alpha.N`, `-rc.N`)
- `update-master.js`: Filter superseded pre-releases, compute `public-release` vs `maintenance-release`, compute repository release references
- `enrichment.js`: Include `release_type` in flattened API data for viewers

**Viewers:**
- Internal viewer: Added Release Type filter (4 checkboxes), renamed Maturity to API Status filter with values Alpha/RC/Initial/Stable, reordered columns (API, Version, API Status, Category, Repository, Release Tag, Release Type, Meta-Release, First Release)
- Portfolio viewer: Pre-release filtering during data load
- All viewers: `release_type` field now available in flattened API data

**Viewer Library (`viewer-lib.js`):**
- Added `getApiStatus(version)` to compute API status from version string
- Added `renderApiStatusBadge(status)` for status badges (Stable, Initial, RC, Alpha)

#### Which issue(s) this PR fixes:

Partial fix for #52 (release-metadata changes will follow in a separate PR)

#### Special notes for reviewers:

- Schema changes are additive and backward compatible
- Pre-releases are filtered if superseded by a public release in the same rX cycle
- Repository release references (`latest_public_release`, `newest_pre_release`) enable fast filtering without scanning all releases within roll-out or bulk change campaigns; might be used also within validation (tooling)
- The internal viewer now has proper API Status filtering (alpha/rc/initial/stable) derived from version strings

#### Changelog input

```
release-note
feat: extend release collector to track pre-releases with release_type field and all repositories with quick-reference release pointers
feat: add Release Type and API Status filters to internal viewer
fix: filter invalid r0.X release tags
```

#### Additional documentation

This section can be blank.

```
docs
See updated master-metadata-schema.yaml for new field definitions
```