### PR TITLE
feat(progress-tracker): consolidate columns and add Last Published

### DIFF
--- a/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
+++ b/workflows/release-progress-tracker/schemas/releases-progress-schema.yaml
@@ -219,6 +219,16 @@ properties:
             m4:
               $ref: "#/$defs/milestone_release"
 
+        last_published:
+          $ref: "#/$defs/milestone_release"
+          description: Most recently published release in the current cycle
+
+        snapshot_api_versions:
+          type: object
+          description: Calculated API versions from release-metadata.yaml on snapshot branch
+          additionalProperties:
+            type: string
+
         warnings:
           type: array
           description: Validation warnings for this entry

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -23,7 +23,11 @@ from typing import Dict, List, Optional
 import yaml
 
 from .github_api import GitHubAPI, RateLimitError
-from .milestone_deriver import build_meta_release_summaries, derive_cycle_releases
+from .milestone_deriver import (
+    build_meta_release_summaries,
+    derive_cycle_releases,
+    derive_last_published,
+)
 from .models import (
     COLLECTOR_VERSION,
     SCHEMA_VERSION,
@@ -140,10 +144,13 @@ def collect_repo_progress(
             snapshot = find_matching_snapshot(branches, target_tag)
             if snapshot:
                 entry.artifacts.snapshot_branch = snapshot
-        # Cross-reference milestones
+        # Cross-reference milestones and last published
         entry.cycle_releases = derive_cycle_releases(
             repo_name, target_tag, meta_release, all_releases,
             planned_api_names,
+        )
+        entry.last_published = derive_last_published(
+            repo_name, target_tag, all_releases, planned_api_names,
         )
         # Generate warnings
         repo_releases = [r for r in all_releases if r.get("repository") == repo_name]
@@ -201,11 +208,59 @@ def collect_repo_progress(
             "url": release_issue.get("url"),
         }
 
-    # Cross-reference M1/M3/M4 from releases-master
+    # Cross-reference M1/M3/M4 and last published from releases-master
     entry.cycle_releases = derive_cycle_releases(
         repo_name, target_tag, meta_release, all_releases,
         planned_api_names,
     )
+    entry.last_published = derive_last_published(
+        repo_name, target_tag, all_releases, planned_api_names,
+    )
+
+    # Read calculated API versions from snapshot's release-metadata.yaml
+    if entry.artifacts.snapshot_branch and entry.state in (
+        ProgressState.SNAPSHOT_ACTIVE, ProgressState.DRAFT_READY,
+        ProgressState.PUBLISHED,
+    ):
+        try:
+            meta_content = api.get_file_content(
+                repo_name, "release-metadata.yaml",
+                ref=entry.artifacts.snapshot_branch,
+            )
+            if meta_content:
+                meta = yaml.safe_load(meta_content)
+                if meta and isinstance(meta.get("apis"), list):
+                    entry.snapshot_api_versions = {
+                        a["api_name"]: a["api_version"]
+                        for a in meta["apis"]
+                        if a.get("api_name") and a.get("api_version")
+                    }
+        except Exception as e:
+            logger.debug(
+                "%s: failed to read release-metadata.yaml from %s: %s",
+                repo_name, entry.artifacts.snapshot_branch, e,
+            )
+
+    # Fallback for PUBLISHED: read from release tag when snapshot branch unavailable
+    if not entry.snapshot_api_versions and entry.state == ProgressState.PUBLISHED and target_tag:
+        try:
+            meta_content = api.get_file_content(
+                repo_name, "release-metadata.yaml",
+                ref=target_tag,
+            )
+            if meta_content:
+                meta = yaml.safe_load(meta_content)
+                if meta and isinstance(meta.get("apis"), list):
+                    entry.snapshot_api_versions = {
+                        a["api_name"]: a["api_version"]
+                        for a in meta["apis"]
+                        if a.get("api_name") and a.get("api_version")
+                    }
+        except Exception as e:
+            logger.debug(
+                "%s: failed to read release-metadata.yaml from tag %s: %s",
+                repo_name, target_tag, e,
+            )
 
     # Generate warnings
     repo_releases = [r for r in all_releases if r.get("repository") == repo_name]

--- a/workflows/release-progress-tracker/scripts/milestone_deriver.py
+++ b/workflows/release-progress-tracker/scripts/milestone_deriver.py
@@ -41,13 +41,7 @@ def derive_cycle_releases(
     if not target_release_tag:
         return CycleReleases()
 
-    # Extract cycle prefix: "r1.1" → "r1.", "r10.2" → "r10."
-    dot_index = target_release_tag.find(".")
-    tag_prefix = (
-        target_release_tag[:dot_index + 1]
-        if dot_index != -1
-        else target_release_tag + "."
-    )
+    tag_prefix = _get_tag_prefix(target_release_tag)
 
     # Filter releases for this repo by tag prefix
     cycle_releases = [
@@ -68,6 +62,70 @@ def derive_cycle_releases(
     m4 = _find_earliest_by_type(cycle_releases, "public-release", planned_apis)
 
     return CycleReleases(m1=m1, m3=m3, m4=m4)
+
+
+def derive_last_published(
+    repo_name: str,
+    target_release_tag: Optional[str],
+    all_releases: List[Dict],
+    planned_apis: List[str],
+) -> Optional[MilestoneRelease]:
+    """Find the most recently published release in the current cycle.
+
+    Returns the latest release (by release_date) regardless of type,
+    or None if no releases exist in the cycle.
+    """
+    if not target_release_tag:
+        return None
+
+    tag_prefix = _get_tag_prefix(target_release_tag)
+
+    cycle_releases = [
+        r for r in all_releases
+        if r.get("repository") == repo_name
+        and (r.get("release_tag") or "").startswith(tag_prefix)
+    ]
+
+    if not cycle_releases:
+        return None
+
+    # Sort by release_date descending, take most recent
+    cycle_releases.sort(key=lambda r: r.get("release_date", ""), reverse=True)
+    latest = cycle_releases[0]
+
+    # Build API version map
+    release_api_versions = {}
+    for api in latest.get("apis", []):
+        name = api.get("api_name")
+        if name:
+            release_api_versions[name] = api.get("api_version")
+
+    apis = [
+        CycleReleaseApi(
+            api_name=name,
+            api_version=release_api_versions.get(name),
+        )
+        for name in planned_apis
+    ]
+
+    return MilestoneRelease(
+        release_tag=latest.get("release_tag"),
+        release_date=latest.get("release_date"),
+        apis=apis,
+    )
+
+
+def _get_tag_prefix(target_release_tag: str) -> str:
+    """Extract cycle prefix from a release tag.
+
+    Examples: "r1.1" → "r1.", "r10.2" → "r10."
+    """
+    dot_index = target_release_tag.find(".")
+    return (
+        target_release_tag[:dot_index + 1]
+        if dot_index != -1
+        else target_release_tag + "."
+    )
 
 
 def _find_earliest_by_type(

--- a/workflows/release-progress-tracker/scripts/models.py
+++ b/workflows/release-progress-tracker/scripts/models.py
@@ -9,8 +9,8 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 # Single source of truth for version constants — update here only
-SCHEMA_VERSION = "1.2.0"
-COLLECTOR_VERSION = "1.2.0"
+SCHEMA_VERSION = "1.3.0"
+COLLECTOR_VERSION = "1.3.0"
 
 
 class ProgressState(Enum):
@@ -145,6 +145,8 @@ class ProgressEntry:
         default_factory=lambda: PublishedContext(None, None)
     )
     cycle_releases: CycleReleases = field(default_factory=CycleReleases)
+    last_published: Optional['MilestoneRelease'] = None
+    snapshot_api_versions: Optional[Dict[str, str]] = None
     warnings: List[ProgressWarning] = field(default_factory=list)
 
     def to_dict(self) -> Dict:
@@ -165,6 +167,10 @@ class ProgressEntry:
         d["artifacts"] = self.artifacts.to_dict()
         d["published_context"] = self.published_context.to_dict()
         d["cycle_releases"] = self.cycle_releases.to_dict()
+        if self.last_published:
+            d["last_published"] = self.last_published.to_dict()
+        if self.snapshot_api_versions:
+            d["snapshot_api_versions"] = self.snapshot_api_versions
         if self.warnings:
             d["warnings"] = [w.to_dict() for w in self.warnings]
         return d

--- a/workflows/release-progress-tracker/templates/progress-template.html
+++ b/workflows/release-progress-tracker/templates/progress-template.html
@@ -98,6 +98,13 @@
 
 .milestone-tag {
   font-weight: 500;
+  text-decoration: none;
+  color: inherit;
+}
+
+a.milestone-tag:hover {
+  text-decoration: underline;
+  color: var(--accent-primary);
 }
 
 .milestone-date {
@@ -270,14 +277,13 @@ tr.not-planned-row:hover td {
           <tr>
             <th onclick="sortTable(0)">API Name <span class="sort-arrow"></span></th>
             <th onclick="sortTable(1)">Target API<br>Version <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(2)">Target API<br>Status <span class="sort-arrow"></span></th>
+            <th onclick="sortTable(2)">Ongoing<br>Release <span class="sort-arrow"></span></th>
             <th onclick="sortTable(3)">Release<br>State <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(4)">Release<br>Type <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(5)">Target<br>Release <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(6)">M1<br>(Alpha) <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(7)">M3<br>(RC) <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(8)">M4<br>(Public) <span class="sort-arrow"></span></th>
-            <th onclick="sortTable(9)">Repository <span class="sort-arrow"></span></th>
+            <th onclick="sortTable(4)">Last<br>Published <span class="sort-arrow"></span></th>
+            <th onclick="sortTable(5)">1st Alpha<br>(M1) <span class="sort-arrow"></span></th>
+            <th onclick="sortTable(6)">1st RC<br>(M3) <span class="sort-arrow"></span></th>
+            <th onclick="sortTable(7)">1st Public<br>(M4) <span class="sort-arrow"></span></th>
+            <th onclick="sortTable(8)">Repository <span class="sort-arrow"></span></th>
           </tr>
         </thead>
         <tbody id="tableBody"></tbody>
@@ -303,15 +309,7 @@ tr.not-planned-row:hover td {
       'not_planned':     { label: 'Not Planned', color: '#C2C9D1', order: 5 }
     };
 
-    const TYPE_SHORT = {
-      'pre-release-alpha': 'alpha',
-      'pre-release-rc': 'rc',
-      'public-release': 'public',
-      'maintenance-release': 'maint.',
-      'none': ''
-    };
-
-    const COL_COUNT = 10;
+    const COL_COUNT = 9;
 
     // Release track display order — update when new meta-releases are added
     const TRACK_ORDER = ['Spring26', 'Sync26', 'Signal27', 'independent', 'Fall25'];
@@ -348,6 +346,8 @@ tr.not-planned-row:hover td {
             cycle_releases: repo.cycle_releases || {},
             warnings: repo.warnings || [],
             dependencies: repo.dependencies || {},
+            last_published: repo.last_published || null,
+            snapshot_api_versions: repo.snapshot_api_versions || null,
             _is_placeholder: true
           });
         } else {
@@ -369,6 +369,8 @@ tr.not-planned-row:hover td {
               cycle_releases: repo.cycle_releases || {},
               warnings: repo.warnings || [],
               dependencies: repo.dependencies || {},
+              last_published: repo.last_published || null,
+              snapshot_api_versions: repo.snapshot_api_versions || null,
               _is_placeholder: false,
               _is_first_in_repo: idx === 0,
               _repo_api_count: repo.apis.length
@@ -525,7 +527,7 @@ tr.not-planned-row:hover td {
     }
 
     /**
-     * Render state badge with optional artifact link and warning icon
+     * Render state badge with warning icon
      */
     function renderStateCell(row) {
       const cfg = STATE_CONFIG[row.state] || { label: row.state, color: '#666' };
@@ -538,33 +540,108 @@ tr.not-planned-row:hover td {
         html += `<span class="warning-icon">&#9888;<span class="warning-tooltip">${tooltipText}</span></span>`;
       }
 
+      return html;
+    }
+
+    /**
+     * Render Ongoing Release cell (3-line: tag, version, artifact link)
+     */
+    function renderOngoingReleaseCell(row) {
+      const state = row.state;
+      const tag = row.target_release_tag;
       const artifacts = row.artifacts || {};
-      let link = '';
 
-      if (row.state === 'snapshot_active' && artifacts.release_pr) {
-        link = `<a href="${artifacts.release_pr.url}" target="_blank" rel="noopener">PR #${artifacts.release_pr.number}</a>`;
-      } else if (row.state === 'draft_ready' && artifacts.draft_release) {
-        link = `<a href="${artifacts.draft_release.url}" target="_blank" rel="noopener">Draft: ${artifacts.draft_release.name}</a>`;
-      } else if (row.state === 'published' && row.github_url && row.target_release_tag) {
-        link = `<a href="${row.github_url}/releases/tag/${row.target_release_tag}" target="_blank" rel="noopener">${row.target_release_tag}</a>`;
+      // Not Planned: show plan data only if it differs from last published
+      if (state === 'not_planned') {
+        const lp = row.last_published;
+        const hasDifferentPlan = tag && (!lp || lp.release_tag !== tag);
+        if (hasDifferentPlan) {
+          const version = row.target_api_version
+            ? `${row.target_api_version} (${row.target_api_status || ''})`
+            : '';
+          return `<span class="milestone-tag">${tag}</span>`
+            + (version ? `<br><span style="font-size:10px;color:var(--text-secondary)">${version}</span>` : '');
+        }
+        return '<span class="milestone-empty">&mdash;</span>';
       }
 
-      // Fallback: show release issue link when primary artifact link is unavailable
-      if (!link && artifacts.release_issue) {
-        link = `<a href="${artifacts.release_issue.url}" target="_blank" rel="noopener">Issue #${artifacts.release_issue.number}</a>`;
+      if (!tag) return '<span class="milestone-empty">&mdash;</span>';
+
+      // Line 1: release tag (clickable for published state)
+      let line1;
+      if (state === 'published') {
+        line1 = `<a href="${row.github_url}/releases/tag/${tag}" target="_blank" rel="noopener" class="milestone-tag">${tag}</a>`;
+      } else {
+        line1 = `<span class="milestone-tag">${tag}</span>`;
       }
 
-      if (link) {
-        html += `<span class="state-artifact">${link}</span>`;
+      // Line 2: API version — use calculated version from snapshot if available
+      let version = '';
+      const snapVersions = row.snapshot_api_versions;
+      if (snapVersions && row.api_name && snapVersions[row.api_name]) {
+        version = snapVersions[row.api_name];
+      } else if (row.target_api_version) {
+        version = row.target_api_status
+          ? `${row.target_api_version} (${row.target_api_status})`
+          : row.target_api_version;
+      }
+
+      // Line 3: artifact link
+      let line3 = '';
+      if (state === 'snapshot_active' && artifacts.release_pr) {
+        line3 = `<a href="${artifacts.release_pr.url}" target="_blank" rel="noopener">PR #${artifacts.release_pr.number}</a>`;
+      } else if (artifacts.release_issue) {
+        line3 = `<a href="${artifacts.release_issue.url}" target="_blank" rel="noopener">Issue #${artifacts.release_issue.number}</a>`;
+      }
+
+      let html = line1;
+      if (version) {
+        html += `<br><span style="font-size:10px;color:var(--text-secondary)">${version}</span>`;
+      }
+      if (line3) {
+        html += `<span class="milestone-date">${line3}</span>`;
       }
 
       return html;
     }
 
     /**
-     * Render a milestone cell (M1, M3, or M4)
+     * Render Last Published cell (3-line: tag link, version, date)
      */
-    function renderMilestoneCell(cycleReleases, milestoneKey, apiName) {
+    function renderLastPublishedCell(row) {
+      const lp = row.last_published;
+      if (!lp || !lp.release_tag) {
+        return '<span class="milestone-empty">&mdash;</span>';
+      }
+
+      // Line 1: release tag (clickable)
+      const tagUrl = `${row.github_url}/releases/tag/${lp.release_tag}`;
+      let html = `<a href="${tagUrl}" target="_blank" rel="noopener" class="milestone-tag">${lp.release_tag}</a>`;
+
+      // Line 2: API version from that release
+      let apiVersion = '';
+      if (lp.apis && row.api_name) {
+        const apiEntry = lp.apis.find(a => a.api_name === row.api_name);
+        if (apiEntry && apiEntry.api_version) {
+          apiVersion = apiEntry.api_version;
+        }
+      }
+      if (apiVersion) {
+        html += `<br><span style="font-size:10px;color:var(--text-secondary)">${apiVersion}</span>`;
+      }
+
+      // Line 3: release date
+      if (lp.release_date) {
+        html += `<span class="milestone-date">${ViewerLib.formatDate(lp.release_date)}</span>`;
+      }
+
+      return html;
+    }
+
+    /**
+     * Render a milestone cell (M1, M3, or M4) with clickable release tag
+     */
+    function renderMilestoneCell(cycleReleases, milestoneKey, apiName, githubUrl) {
       if (!cycleReleases || !cycleReleases[milestoneKey]) {
         return '<span class="milestone-empty">&mdash;</span>';
       }
@@ -586,7 +663,8 @@ tr.not-planned-row:hover td {
         ? ViewerLib.formatDate(milestone.release_date)
         : '';
 
-      let html = `<span class="milestone-tag">${milestone.release_tag}</span>`;
+      const tagUrl = `${githubUrl}/releases/tag/${milestone.release_tag}`;
+      let html = `<a href="${tagUrl}" target="_blank" rel="noopener" class="milestone-tag">${milestone.release_tag}</a>`;
       if (apiVersion) {
         html += `<br><span style="font-size:10px;color:var(--text-secondary)">${apiVersion}</span>`;
       }
@@ -615,24 +693,19 @@ tr.not-planned-row:hover td {
       // Target API Version
       const versionCell = row.target_api_version || '&mdash;';
 
-      // Target API Status
-      const statusCell = row.target_api_status || '&mdash;';
+      // Ongoing Release (3-line cell)
+      const ongoingCell = renderOngoingReleaseCell(row);
 
       // Release State
       const stateCell = renderStateCell(row);
 
-      // Release Type (plain text with tooltip)
-      const typeText = TYPE_SHORT[row.target_release_type] || row.target_release_type || '';
-      const typeCell = typeText || '&mdash;';
-      const typeTitle = row.target_release_type || '';
+      // Last Published (3-line cell)
+      const lastPubCell = renderLastPublishedCell(row);
 
-      // Target Release
-      const releaseCell = row.target_release_tag || '&mdash;';
-
-      // Milestones
-      const m1Cell = renderMilestoneCell(row.cycle_releases, 'm1', row.api_name);
-      const m3Cell = renderMilestoneCell(row.cycle_releases, 'm3', row.api_name);
-      const m4Cell = renderMilestoneCell(row.cycle_releases, 'm4', row.api_name);
+      // Milestones (with clickable tags)
+      const m1Cell = renderMilestoneCell(row.cycle_releases, 'm1', row.api_name, row.github_url);
+      const m3Cell = renderMilestoneCell(row.cycle_releases, 'm3', row.api_name, row.github_url);
+      const m4Cell = renderMilestoneCell(row.cycle_releases, 'm4', row.api_name, row.github_url);
 
       // Repository (link)
       const repoCell = `<a href="${row.github_url}" target="_blank" rel="noopener">${row.repository}</a>`;
@@ -640,10 +713,9 @@ tr.not-planned-row:hover td {
       tr.innerHTML = `
         <td>${apiNameText}</td>
         <td>${versionCell}</td>
-        <td>${statusCell}</td>
+        <td class="milestone-cell">${ongoingCell}</td>
         <td>${stateCell}</td>
-        <td title="${typeTitle}">${typeCell}</td>
-        <td>${releaseCell}</td>
+        <td class="milestone-cell">${lastPubCell}</td>
         <td class="milestone-cell">${m1Cell}</td>
         <td class="milestone-cell">${m3Cell}</td>
         <td class="milestone-cell">${m4Cell}</td>
@@ -771,14 +843,13 @@ tr.not-planned-row:hover td {
       const sortKeys = [
         r => r.api_name.toLowerCase(),                           // 0: API Name
         r => r.target_api_version,                               // 1: Target API Version
-        r => r.target_api_status || '',                          // 2: Target API Status
+        r => r.target_release_tag || '',                         // 2: Ongoing Release (by tag)
         r => (STATE_CONFIG[r.state] || {}).order ?? 99,          // 3: Release State
-        r => r.target_release_type || '',                        // 4: Release Type
-        r => r.target_release_tag || '',                         // 5: Target Release
-        r => getMilestoneDate(r.cycle_releases, 'm1'),           // 6: M1
-        r => getMilestoneDate(r.cycle_releases, 'm3'),           // 7: M3
-        r => getMilestoneDate(r.cycle_releases, 'm4'),           // 8: M4
-        r => r.repository.toLowerCase(),                         // 9: Repository
+        r => getLastPublishedDate(r),                            // 4: Last Published (by date)
+        r => getMilestoneDate(r.cycle_releases, 'm1'),           // 5: 1st Alpha (M1)
+        r => getMilestoneDate(r.cycle_releases, 'm3'),           // 6: 1st RC (M3)
+        r => getMilestoneDate(r.cycle_releases, 'm4'),           // 7: 1st Public (M4)
+        r => r.repository.toLowerCase(),                         // 8: Repository
       ];
 
       const getKey = sortKeys[columnIndex] || sortKeys[0];
@@ -819,6 +890,14 @@ tr.not-planned-row:hover td {
         return Infinity;
       }
       return new Date(cycleReleases[key].release_date).getTime();
+    }
+
+    /**
+     * Get last published date as sortable value
+     */
+    function getLastPublishedDate(row) {
+      if (!row.last_published || !row.last_published.release_date) return Infinity;
+      return new Date(row.last_published.release_date).getTime();
     }
 
     /**
@@ -935,10 +1014,13 @@ tr.not-planned-row:hover td {
      */
     function exportCSV() {
       const headers = [
-        'API Name', 'Target API Version', 'Target API Status',
-        'Release State', 'Release Type', 'Target Release',
+        'API Name', 'Target API Version',
+        'Ongoing Release Tag', 'Ongoing Release Version', 'Ongoing Release Status',
+        'Release State',
+        'Last Published Tag', 'Last Published Version', 'Last Published Date',
         'Release Track', 'Meta-Release',
-        'M1 Tag', 'M1 Date', 'M3 Tag', 'M3 Date', 'M4 Tag', 'M4 Date',
+        '1st Alpha Tag', '1st Alpha Date', '1st RC Tag', '1st RC Date',
+        '1st Public Tag', '1st Public Date',
         'Repository', 'Warnings'
       ];
 
@@ -946,13 +1028,22 @@ tr.not-planned-row:hover td {
         const m1 = (row.cycle_releases || {}).m1 || {};
         const m3 = (row.cycle_releases || {}).m3 || {};
         const m4 = (row.cycle_releases || {}).m4 || {};
+        const lp = row.last_published || {};
+        const lpApi = (lp.apis || []).find(a => a.api_name === row.api_name);
+        const snapVer = (row.snapshot_api_versions && row.api_name)
+          ? row.snapshot_api_versions[row.api_name] || ''
+          : '';
+        const ongoingVer = snapVer || row.target_api_version || '';
         return [
           row.api_name || row.repository,
           row.target_api_version,
+          row.target_release_tag,
+          ongoingVer,
           row.target_api_status,
           row.state,
-          row.target_release_type,
-          row.target_release_tag,
+          lp.release_tag || '',
+          (lpApi && lpApi.api_version) || '',
+          lp.release_date || '',
           row.release_track,
           row.meta_release,
           m1.release_tag || '',

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -436,7 +436,7 @@ class TestCollectAll:
         assert "last_updated" in meta
         assert "last_checked" in meta
         assert "releases_master_updated" in meta
-        assert meta["schema_version"] == "1.2.0"
+        assert meta["schema_version"] == "1.3.0"
         assert "collection_stats" not in meta  # Full stats removed from output
         assert meta["repos_scanned"] == 2      # Stable stats restored
         assert meta["repos_with_plan"] == 2

--- a/workflows/release-progress-tracker/tests/test_milestone_deriver.py
+++ b/workflows/release-progress-tracker/tests/test_milestone_deriver.py
@@ -4,7 +4,9 @@ import pytest
 
 from scripts.milestone_deriver import (
     derive_cycle_releases,
+    derive_last_published,
     build_meta_release_summaries,
+    _get_tag_prefix,
 )
 from scripts.models import (
     ProgressEntry, ProgressState, ApiEntry,
@@ -191,6 +193,88 @@ class TestDeriveCycleReleases:
         )
         assert cr.m1.release_tag == "r1.1"
         assert cr.m1.apis[0].api_version == "0.1.0-alpha.1"
+
+
+class TestGetTagPrefix:
+    """Test tag prefix extraction helper."""
+
+    def test_standard_tag(self):
+        assert _get_tag_prefix("r4.1") == "r4."
+
+    def test_double_digit_major(self):
+        assert _get_tag_prefix("r10.2") == "r10."
+
+    def test_no_dot(self):
+        assert _get_tag_prefix("r4") == "r4."
+
+
+class TestDeriveLastPublished:
+    """Test most-recent-release derivation."""
+
+    def test_finds_most_recent_release(self):
+        """Should return the latest release by date, regardless of type."""
+        result = derive_last_published(
+            "QualityOnDemand", "r4.1", SAMPLE_RELEASES,
+            ["quality-on-demand"],
+        )
+        assert result is not None
+        # r4.2 (2026-03-15) is more recent than r4.1 (2026-02-10)
+        assert result.release_tag == "r4.2"
+        assert result.release_date == "2026-03-15T10:00:00Z"
+        assert result.apis[0].api_version == "1.2.0-rc.1"
+
+    def test_returns_none_when_no_target_tag(self):
+        result = derive_last_published(
+            "QualityOnDemand", None, SAMPLE_RELEASES,
+            ["quality-on-demand"],
+        )
+        assert result is None
+
+    def test_returns_none_when_no_matching_releases(self):
+        result = derive_last_published(
+            "NonExistentRepo", "r1.1", SAMPLE_RELEASES,
+            ["some-api"],
+        )
+        assert result is None
+
+    def test_only_matches_same_tag_prefix(self):
+        """Releases from different cycle (r3.x) should not appear."""
+        result = derive_last_published(
+            "QualityOnDemand", "r3.1", SAMPLE_RELEASES,
+            ["quality-on-demand"],
+        )
+        assert result is not None
+        assert result.release_tag == "r3.5"
+
+    def test_multi_api_versions(self):
+        """Should extract correct per-API version from multi-API release."""
+        releases = [{
+            "repository": "MultiApiRepo",
+            "release_tag": "r1.1",
+            "release_date": "2026-03-01T00:00:00Z",
+            "release_type": "pre-release-alpha",
+            "apis": [
+                {"api_name": "api-a", "api_version": "1.0.0-alpha.1"},
+                {"api_name": "api-b", "api_version": "2.0.0-alpha.1"},
+            ],
+        }]
+        result = derive_last_published(
+            "MultiApiRepo", "r1.1", releases,
+            ["api-a", "api-b", "api-c"],
+        )
+        assert result is not None
+        assert result.apis[0].api_version == "1.0.0-alpha.1"
+        assert result.apis[1].api_version == "2.0.0-alpha.1"
+        assert result.apis[2].api_version is None  # Not in release
+
+    def test_single_release_in_cycle(self):
+        """With only one release, it should be returned as last published."""
+        result = derive_last_published(
+            "DeviceLocation", "r5.1", SAMPLE_RELEASES,
+            ["location-verification"],
+        )
+        assert result is not None
+        assert result.release_tag == "r5.1"
 
 
 class TestBuildMetaReleaseSummaries:

--- a/workflows/release-progress-tracker/tests/test_models.py
+++ b/workflows/release-progress-tracker/tests/test_models.py
@@ -86,6 +86,9 @@ class TestProgressEntry:
             state=ProgressState.SNAPSHOT_ACTIVE,
             artifacts=ArtifactInfo(snapshot_branch="release-snapshot/r4.2-abc"),
             published_context=PublishedContext("r3.2", "r4.1"),
+            last_published=MilestoneRelease("r4.1", "2026-02-10T14:30:00Z",
+                [CycleReleaseApi("quality-on-demand", "1.2.0-alpha.1")]),
+            snapshot_api_versions={"quality-on-demand": "1.2.0-rc.1"},
             warnings=[ProgressWarning("W001", "test", "warning")],
         )
         d = entry.to_dict()
@@ -93,6 +96,9 @@ class TestProgressEntry:
         assert d["repository"] == "QualityOnDemand"
         assert d["state"] == "snapshot_active"
         assert d["published_context"]["latest_public_release"] == "r3.2"
+        assert d["last_published"]["release_tag"] == "r4.1"
+        assert d["last_published"]["apis"][0]["api_version"] == "1.2.0-alpha.1"
+        assert d["snapshot_api_versions"]["quality-on-demand"] == "1.2.0-rc.1"
         assert len(d["warnings"]) == 1
         assert d["warnings"][0]["code"] == "W001"
 
@@ -100,7 +106,20 @@ class TestProgressEntry:
         yaml_str = yaml.dump(d, default_flow_style=False)
         reloaded = yaml.safe_load(yaml_str)
         assert reloaded["state"] == "snapshot_active"
+        assert reloaded["last_published"]["release_tag"] == "r4.1"
+        assert reloaded["snapshot_api_versions"]["quality-on-demand"] == "1.2.0-rc.1"
         assert reloaded["warnings"][0]["code"] == "W001"
+
+    def test_no_last_published_omitted(self):
+        entry = ProgressEntry(
+            repository="TestRepo",
+            github_url="https://github.com/camaraproject/TestRepo",
+            target_release_type="pre-release-alpha",
+            state=ProgressState.PLANNED,
+        )
+        d = entry.to_dict()
+        assert "last_published" not in d
+        assert "snapshot_api_versions" not in d
 
     def test_not_planned_entry(self):
         entry = ProgressEntry(
@@ -139,7 +158,7 @@ class TestProgressData:
         )
         d = data.to_dict()
 
-        assert d["metadata"]["schema_version"] == "1.2.0"
+        assert d["metadata"]["schema_version"] == "1.3.0"
         assert d["metadata"]["last_checked"] == "2026-03-15T10:00:00Z"
         assert d["metadata"]["releases_master_updated"] == "2026-03-15T04:35:00Z"
         assert "collection_stats" not in d["metadata"]  # Full stats removed from output
@@ -152,4 +171,4 @@ class TestProgressData:
         # Full YAML round-trip
         yaml_str = yaml.dump(d, default_flow_style=False, sort_keys=False)
         reloaded = yaml.safe_load(yaml_str)
-        assert reloaded["metadata"]["collector_version"] == "1.2.0"
+        assert reloaded["metadata"]["collector_version"] == "1.3.0"


### PR DESCRIPTION
#### What type of PR is this?

enhancement/feature

#### What this PR does / why we need it:

Consolidates the Release Progress Tracker viewer from 10 columns to 9 with better information density:

- **Ongoing Release** column replaces three separate columns (Target API Status, Release Type, Target Release) with a 3-line cell showing release tag, calculated API version, and artifact link
- **Last Published** column shows the most recent release in the current cycle with clickable tag, API version, and date
- **Milestone headers** renamed to "1st Alpha (M1)", "1st RC (M3)", "1st Public (M4)" with clickable release tag links
- **Calculated versions** read from `release-metadata.yaml` on snapshot branches (or release tags for published state)

Data collection: new `derive_last_published()`, new `snapshot_api_versions` field, schema version bumped to 1.3.0.

#### Which issue(s) this PR fixes:

Fixes camaraproject/ReleaseManagement#432

#### Special notes for reviewers:

The viewer with live data is deployed at:
**https://hdamker.github.io/ReleaseManagement/progress.html**

All 105 unit tests pass. Fork-based E2E test verified all 5 states render correctly including calculated versions for published state.

#### Changelog input

```
release-note
Consolidate progress tracker viewer from 10 to 9 columns: replace Target API Status / Release Type / Target Release with "Ongoing Release", add "Last Published" column, make milestone tags clickable.
```

#### Additional documentation

```
docs
N/A
```