### PR TITLE
Rename meta_release 'None (Sandbox)' to 'Independent'

### DIFF
--- a/campaigns/release-info/docs/01-architecture.md
+++ b/campaigns/release-info/docs/01-architecture.md
@@ -39,7 +39,7 @@ Executes in parallel for each repository from the matrix.
 2. **Read release data:**
    - Parse releases-master.yaml
    - Filter by repository name
-   - Exclude sandbox releases
+   - Exclude independent releases
    - Sort by semver to find latest public release
    - Output JSON for templating
 

--- a/campaigns/release-info/docs/04-actions.md
+++ b/campaigns/release-info/docs/04-actions.md
@@ -23,7 +23,7 @@ Parses `data/releases-master.yaml` to extract release information for a specific
 **Logic:**
 1. Load YAML file
 2. Filter releases by repository name
-3. Exclude sandbox releases (`meta_release` contains "Sandbox")
+3. Exclude independent releases (`meta_release` is "Independent")
 4. Sort by semver (extract from `release_tag` like "r3.2")
 5. Select latest (highest version)
 6. Output all APIs from that release

--- a/campaigns/release-plan-rollout/actions/generate-release-plan/dist/index.js
+++ b/campaigns/release-plan-rollout/actions/generate-release-plan/dist/index.js
@@ -5044,7 +5044,7 @@ function generateApiEntry(api) {
         if (hasReleases) {
             // Case 1: Repository WITH releases
             const release = targetRelease;
-            const releaseTrack = release.meta_release && !release.meta_release.includes('Sandbox')
+            const releaseTrack = release.meta_release && !['Independent', 'None (Sandbox)'].includes(release.meta_release)
                 ? 'meta-release'
                 : 'independent';
             // Template data

--- a/campaigns/release-plan-rollout/actions/generate-release-plan/src/index.ts
+++ b/campaigns/release-plan-rollout/actions/generate-release-plan/src/index.ts
@@ -163,7 +163,7 @@ function generateApiEntry(api: APIEntry): string {
     if (hasReleases) {
       // Case 1: Repository WITH releases
       const release = targetRelease!;
-      const releaseTrack = release.meta_release && !release.meta_release.includes('Sandbox')
+      const releaseTrack = release.meta_release && !['Independent', 'None (Sandbox)'].includes(release.meta_release)
         ? 'meta-release'
         : 'independent';
 

--- a/workflows/release-collector/schemas/master-metadata-schema.yaml
+++ b/workflows/release-collector/schemas/master-metadata-schema.yaml
@@ -1,6 +1,10 @@
 # Master Metadata Schema
 # Schema for releases-master.yaml containing GitHub facts with format corrections only
-# Version: 3.0.0
+# Version: 3.1.0
+#
+# Changes in 3.1.0:
+# - Renamed meta_release value "None (Sandbox)" to "Independent" for releases outside
+#   meta-release cycles
 #
 # Changes in 3.0.0 (ADR-0004: Native Release Metadata Adoption):
 # - Removed apis[].file_name (no downstream consumers, not in native metadata)
@@ -89,7 +93,7 @@ properties:
         meta_release:
           type: string
           description: Assigned meta-release cycle from configuration
-          examples: ["Fall24", "Spring25", "Fall25", "Sandbox", "None"]
+          examples: ["Fall24", "Spring25", "Fall25", "Independent", "None"]
 
         github_url:
           type: string

--- a/workflows/release-collector/scripts/analyze-release.js
+++ b/workflows/release-collector/scripts/analyze-release.js
@@ -259,7 +259,7 @@ function getMetaRelease(repository, releaseTag, mappings) {
     }
   }
 
-  return 'None (Sandbox)';  // rX.Y format but not mapped
+  return 'Independent';  // rX.Y format but not mapped
 }
 
 /**

--- a/workflows/release-collector/scripts/generate-reports.js
+++ b/workflows/release-collector/scripts/generate-reports.js
@@ -5,7 +5,7 @@
  *
  * Generates JSON report files for each meta-release from the master metadata.
  * Applies runtime enrichment from API landscape data.
- * Creates separate files for Fall24, Spring25, Fall25, PreFall24, Sandbox, etc.
+ * Creates separate files for Fall24, Spring25, Fall25, PreFall24, Independent, etc.
  */
 
 const fs = require('fs');

--- a/workflows/release-collector/scripts/update-master.js
+++ b/workflows/release-collector/scripts/update-master.js
@@ -41,7 +41,7 @@ function loadMaster() {
       metadata: {
         last_updated: null,
         workflow_version: "3.0.0",
-        schema_version: "3.0.0"
+        schema_version: "3.1.0"
       },
       releases: [],
       repositories: []
@@ -53,7 +53,7 @@ function loadMaster() {
     master.repositories = [];
   }
   // Update schema version if needed
-  master.metadata.schema_version = "3.0.0";
+  master.metadata.schema_version = "3.1.0";
   return master;
 }
 
@@ -76,7 +76,7 @@ function getMetaRelease(repository, releaseTag, mappings) {
     }
   }
 
-  return 'None (Sandbox)';  // rX.Y format but not mapped to a meta-release
+  return 'Independent';  // rX.Y format but not mapped to a meta-release
 }
 
 /**

--- a/workflows/release-collector/templates/internal-template.html
+++ b/workflows/release-collector/templates/internal-template.html
@@ -290,7 +290,7 @@
       background-color: rgba(139, 92, 246, 0.08);
     }
 
-    .sandbox-row {
+    .independent-row {
       background-color: rgba(251, 146, 60, 0.1);
     }
 
@@ -455,7 +455,7 @@
       background: #f59e0b;
     }
 
-    .status-sandbox {
+    .status-independent {
       background: var(--warning-color);
     }
 
@@ -669,7 +669,7 @@
               <option value="Fall24">Fall24</option>
               <option value="Spring25">Spring25</option>
               <option value="Fall25">Fall25</option>
-              <option value="None (Sandbox)">Sandbox</option>
+              <option value="Independent">Independent</option>
             </select>
           </div>
           <button class="clear-filters-btn" onclick="clearAllFilters()">Clear Filters</button>
@@ -848,13 +848,13 @@
       const rcCount = data.apis.filter(a => a.release_type === 'pre-release-rc').length;
       const publicCount = data.apis.filter(a => a.release_type === 'public-release' || !a.release_type).length;
       const maintenanceCount = data.apis.filter(a => a.release_type === 'maintenance-release').length;
-      const sandboxCount = data.apis.filter(a => a.meta_release === 'None (Sandbox)').length;
+      const independentCount = data.apis.filter(a => a.meta_release === 'Independent').length;
 
       footerDiv.innerHTML = `
         Report generated: ${generated} |
         Total: ${totalAPIs} |
         Alpha: ${alphaCount} | RC: ${rcCount} | Public: ${publicCount} | Maint: ${maintenanceCount} |
-        Sandbox: ${sandboxCount}
+        Independent: ${independentCount}
       `;
 
       buildCategoryPills();
@@ -1074,8 +1074,8 @@
         if (releaseType.startsWith('pre-release')) {
           row.classList.add('prerelease-row');
         }
-        if (api.meta_release === 'None (Sandbox)') {
-          row.classList.add('sandbox-row');
+        if (api.meta_release === 'Independent') {
+          row.classList.add('independent-row');
         }
 
         if (api.repository_archived) {
@@ -1087,7 +1087,7 @@
           releaseType === 'pre-release-alpha' ? 'status-prerelease-alpha' :
           releaseType === 'pre-release-rc' ? 'status-prerelease-rc' :
           releaseType === 'maintenance-release' ? 'status-maintenance' :
-          api.meta_release === 'None (Sandbox)' ? 'status-sandbox' :
+          api.meta_release === 'Independent' ? 'status-independent' :
             'status-public';
 
         // Release type display
@@ -1105,7 +1105,7 @@
           <td><a href="${api.github_url.replace(/\/releases\/tag\/.*$/, '')}" target="_blank">${api.repository}</a>${archivedBadge}</td>
           <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
           <td>${releaseTypeLabel}</td>
-          <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
+          <td>${api.meta_release}</td>
           <td>${api.first_release || '-'}</td>
           <td><button class="debug-btn" onclick='showDebug(${JSON.stringify(api.api_name)}, ${JSON.stringify(api.api_version)}, ${JSON.stringify(api.release_tag)})'>🔍</button></td>
         `;
@@ -1178,7 +1178,7 @@
           const rowClasses = [];
           const releaseType = api.release_type || 'public-release';
           if (releaseType.startsWith('pre-release')) rowClasses.push('prerelease-row');
-          if (api.meta_release === 'None (Sandbox)') rowClasses.push('sandbox-row');
+          if (api.meta_release === 'Independent') rowClasses.push('independent-row');
           rowClasses.push('repo-row');
 
           const releaseTypeLabel = releaseType === 'pre-release-alpha' ? 'Alpha' :
@@ -1194,7 +1194,7 @@
               <td>${api.portfolio_category || '-'}</td>
               <td><a href="${api.github_url}" target="_blank">${api.release_tag}</a></td>
               <td>${releaseTypeLabel}</td>
-              <td>${api.meta_release === 'None (Sandbox)' ? 'Sandbox' : api.meta_release}</td>
+              <td>${api.meta_release}</td>
             </tr>
           `;
         });

--- a/workflows/release-collector/templates/portfolio-template.html
+++ b/workflows/release-collector/templates/portfolio-template.html
@@ -135,7 +135,7 @@
       border-color: #0092f5;
     }
 
-    .timeline-item.sandbox {
+    .timeline-item.independent {
       border-color: #f5a742;
       background: #fff8ed;
     }
@@ -267,7 +267,7 @@
       border-color: var(--border-light);
     }
 
-    html[data-theme="dark"] .timeline-item.sandbox {
+    html[data-theme="dark"] .timeline-item.independent {
       background: rgba(245, 167, 66, 0.1);
       border-color: var(--warning-color);
     }
@@ -362,7 +362,7 @@
         </table>
         <div class="footer-note"
           style="margin-top: 15px; padding: 10px; background: #f8f9fa; border-radius: 6px; font-size: 13px; color: #666;">
-          Note: This table shows only meta-releases (Fall24, Spring25, Fall25). Sandbox releases are shown in API
+          Note: This table shows only meta-releases (Fall24, Spring25, Fall25). Independent releases are shown in API
           Evolution and Repository views.
         </div>
       </div>
@@ -398,7 +398,7 @@
 
     // Meta-release constants
     const META_RELEASES = ['Fall24', 'Spring25', 'Fall25'];
-    const SANDBOX_RELEASE = 'None (Sandbox)';
+    const INDEPENDENT_RELEASE = 'Independent';
 
     /**
      * Initialize iframe detection
@@ -514,7 +514,7 @@
         const firstAPI = versions[0];
         const latestAPI = versions[versions.length - 1];
 
-        // Only include meta-releases (exclude Sandbox)
+        // Only include meta-releases (exclude Independent)
         let metaVersions = versions.filter(v =>
           META_RELEASES.includes(v.meta_release)
         );
@@ -770,7 +770,7 @@
     }
 
     /**
-     * Render meta-release table (excludes Sandbox)
+     * Render meta-release table (excludes Independent)
      */
     function renderMetaReleaseTable() {
       const tableData = createMetaReleaseTableData(filteredData);
@@ -844,7 +844,7 @@
     }
 
     /**
-     * Render API evolution view (includes Sandbox)
+     * Render API evolution view (includes Independent)
      */
     function renderAPIEvolution() {
       let grouped = groupAPIsByName(filteredData);
@@ -896,12 +896,12 @@
           }
 
           const item = document.createElement('div');
-          const isSandbox = version.meta_release === SANDBOX_RELEASE;
-          item.className = `timeline-item ${isSandbox ? 'sandbox' : 'meta-release'}`;
+          const isIndependent = version.meta_release === INDEPENDENT_RELEASE;
+          item.className = `timeline-item ${isIndependent ? 'independent' : 'meta-release'}`;
 
           item.innerHTML = `
             <div>
-              <div class="release-label">${isSandbox ? 'Sandbox' : version.meta_release}</div>
+              <div class="release-label">${version.meta_release}</div>
               <div class="release-version">${version.api_version}</div>
               ${ViewerLib.renderMaturityBadge(version.maturity)}
             </div>
@@ -919,7 +919,7 @@
     }
 
     /**
-     * Render repository view (includes Sandbox)
+     * Render repository view (includes Independent)
      */
     function renderRepositoryView() {
       let grouped = groupAPIsByRepository(filteredData);
@@ -972,9 +972,7 @@
           apiItem.className = 'repo-api-item';
 
           const releaseInfo = versions.map(v => {
-            const isSandbox = v.meta_release === SANDBOX_RELEASE;
-            const label = isSandbox ? 'Sandbox' : v.meta_release;
-            return `${label}: ${v.api_version}`;
+            return `${v.meta_release}: ${v.api_version}`;
           }).join(' → ');
 
           apiItem.innerHTML = `

--- a/workflows/release-progress-tracker/scripts/collect_progress.py
+++ b/workflows/release-progress-tracker/scripts/collect_progress.py
@@ -129,8 +129,9 @@ def _check_completed_state(entry: ProgressEntry, all_releases: List[Dict]) -> Pr
     return ProgressState.COMPLETED
 
 
-# meta_release values that indicate a sandbox / non-meta-release repo
-_SANDBOX_META_RELEASES = {"None (Sandbox)", "None"}
+# meta_release values that indicate an independent / non-meta-release repo
+# Includes legacy "None (Sandbox)" for backward compatibility with old releases-master.yaml data
+_INDEPENDENT_META_RELEASES = {"Independent", "None (Sandbox)", "None"}
 
 
 def collect_historical_entries(
@@ -144,14 +145,14 @@ def collect_historical_entries(
     These entries carry M1/M3/M4 and last_published data from releases-master.yaml.
     No GitHub API calls are made.
 
-    Sandbox repos (meta_release in _SANDBOX_META_RELEASES):
+    Independent repos (meta_release in _INDEPENDENT_META_RELEASES):
     - If an active entry covers the same repo/tag-prefix → skip (active entry wins).
     - Otherwise → create a HISTORICAL entry with release_track="independent".
     """
     if active_entries is None:
         active_entries = []
 
-    # Build (repo, tag_prefix) set from active entries for sandbox resolution
+    # Build (repo, tag_prefix) set from active entries for independent release resolution
     active_by_repo_prefix = {
         (e.repository, _tag_prefix(e.target_release_tag))
         for e in active_entries
@@ -175,7 +176,7 @@ def collect_historical_entries(
         if (repo, meta_release) in active_repo_meta_releases:
             continue
 
-        is_sandbox = meta_release in _SANDBOX_META_RELEASES
+        is_independent = meta_release in _INDEPENDENT_META_RELEASES
 
         # Find best release for deriving the cycle tag and API list.
         # target_tag: highest-priority release type wins (public > rc > alpha > maintenance).
@@ -208,7 +209,7 @@ def collect_historical_entries(
         if not target_tag:
             continue
 
-        if is_sandbox:
+        if is_independent:
             prefix = _tag_prefix(target_tag)
             if (repo, prefix) in active_by_repo_prefix:
                 continue  # Active entry already covers this repo/cycle

--- a/workflows/release-progress-tracker/scripts/milestone_deriver.py
+++ b/workflows/release-progress-tracker/scripts/milestone_deriver.py
@@ -23,8 +23,8 @@ def derive_cycle_releases(
     """Derive M1/M3/M4 milestone releases for a repo in a release cycle.
 
     Matches releases by tag prefix (e.g., "r1." matches r1.1, r1.2, etc.)
-    rather than meta_release label, so repos with "None (Sandbox)" in
-    releases-master.yaml still get milestone data.
+    rather than meta_release label, so repos with "Independent" (or legacy
+    "None (Sandbox)") in releases-master.yaml still get milestone data.
 
     Args:
         repo_name: Repository name to filter releases for.

--- a/workflows/release-progress-tracker/scripts/warnings.py
+++ b/workflows/release-progress-tracker/scripts/warnings.py
@@ -139,8 +139,8 @@ def _check_meta_release_mismatch(
     differs from the plan's meta_release, this may indicate a configuration
     issue (e.g., repo assigned to wrong meta-release cycle).
 
-    Skips releases labeled "None (Sandbox)" — these are repos not yet
-    assigned to a meta-release cycle, which is expected for new repos.
+    Skips releases labeled "Independent" (or legacy "None (Sandbox)") — these
+    are repos not assigned to a meta-release cycle, which is expected.
     """
     if not entry.meta_release or not entry.target_release_tag:
         return []
@@ -159,7 +159,7 @@ def _check_meta_release_mismatch(
         if (
             rel_tag.startswith(tag_prefix)
             and rel_meta
-            and rel_meta != "None (Sandbox)"
+            and rel_meta not in ("Independent", "None (Sandbox)")
             and rel_meta != entry.meta_release
         ):
             return [ProgressWarning(

--- a/workflows/release-progress-tracker/tests/test_collect_progress.py
+++ b/workflows/release-progress-tracker/tests/test_collect_progress.py
@@ -19,14 +19,14 @@ from scripts.collect_progress import (
 from scripts.github_api import GitHubAPI
 from scripts.models import ApiEntry, CycleReleases, ProgressEntry, ProgressState, PublishedContext
 
-SANDBOX_RELEASE = {
-    "repository": "SandboxRepo",
+INDEPENDENT_RELEASE = {
+    "repository": "IndependentRepo",
     "release_tag": "r2.1",
     "release_date": "2025-11-20T10:00:00Z",
-    "meta_release": "None (Sandbox)",
+    "meta_release": "Independent",
     "release_type": "public-release",
-    "github_url": "https://github.com/camaraproject/SandboxRepo/releases/tag/r2.1",
-    "apis": [{"api_name": "sandbox-api", "api_version": "1.0.0"}],
+    "github_url": "https://github.com/camaraproject/IndependentRepo/releases/tag/r2.1",
+    "apis": [{"api_name": "independent-api", "api_version": "1.0.0"}],
 }
 
 
@@ -814,40 +814,40 @@ class TestCollectHistoricalEntries:
         entries = collect_historical_entries([release_no_meta], set(), {})
         assert len(entries) == 0
 
-    def test_sandbox_without_active_creates_independent(self):
+    def test_independent_without_active_creates_entry(self):
         entries = collect_historical_entries(
-            [SANDBOX_RELEASE], set(),
-            {"SandboxRepo": "https://github.com/camaraproject/SandboxRepo"},
+            [INDEPENDENT_RELEASE], set(),
+            {"IndependentRepo": "https://github.com/camaraproject/IndependentRepo"},
         )
         assert len(entries) == 1
         assert entries[0].release_track == "independent"
         assert entries[0].meta_release is None
         assert entries[0].state == ProgressState.HISTORICAL
 
-    def test_sandbox_with_active_same_prefix_skipped(self):
+    def test_independent_with_active_same_prefix_skipped(self):
         active = ProgressEntry(
-            repository="SandboxRepo",
-            github_url="https://github.com/camaraproject/SandboxRepo",
+            repository="IndependentRepo",
+            github_url="https://github.com/camaraproject/IndependentRepo",
             target_release_tag="r2.1",
             state=ProgressState.PLANNED,
         )
         entries = collect_historical_entries(
-            [SANDBOX_RELEASE], set(),
-            {"SandboxRepo": "https://github.com/camaraproject/SandboxRepo"},
+            [INDEPENDENT_RELEASE], set(),
+            {"IndependentRepo": "https://github.com/camaraproject/IndependentRepo"},
             active_entries=[active],
         )
         assert len(entries) == 0
 
-    def test_sandbox_with_active_different_prefix_creates_entry(self):
+    def test_independent_with_active_different_prefix_creates_entry(self):
         active = ProgressEntry(
-            repository="SandboxRepo",
-            github_url="https://github.com/camaraproject/SandboxRepo",
+            repository="IndependentRepo",
+            github_url="https://github.com/camaraproject/IndependentRepo",
             target_release_tag="r3.1",  # different cycle prefix (r3. vs r2.)
             state=ProgressState.PLANNED,
         )
         entries = collect_historical_entries(
-            [SANDBOX_RELEASE], set(),
-            {"SandboxRepo": "https://github.com/camaraproject/SandboxRepo"},
+            [INDEPENDENT_RELEASE], set(),
+            {"IndependentRepo": "https://github.com/camaraproject/IndependentRepo"},
             active_entries=[active],
         )
         assert len(entries) == 1
@@ -874,29 +874,29 @@ class TestCollectAllWithHistorical:
         assert dev_entry.state == ProgressState.HISTORICAL
         assert dev_entry.source == "historical"
 
-    def test_sandbox_repo_appears_as_independent_historical(self, tmp_path):
-        master_with_sandbox = {
+    def test_independent_repo_appears_as_historical(self, tmp_path):
+        master_with_independent = {
             "metadata": SAMPLE_MASTER["metadata"],
             "repositories": [
                 {
-                    "repository": "SandboxRepo",
-                    "github_url": "https://github.com/camaraproject/SandboxRepo",
+                    "repository": "IndependentRepo",
+                    "github_url": "https://github.com/camaraproject/IndependentRepo",
                     "latest_public_release": "r2.1",
                     "newest_pre_release": None,
                 },
             ],
-            "releases": [SANDBOX_RELEASE],
+            "releases": [INDEPENDENT_RELEASE],
         }
         master_file = tmp_path / "releases-master.yaml"
         output_file = tmp_path / "releases-progress.yaml"
-        master_file.write_text(yaml.dump(master_with_sandbox))
+        master_file.write_text(yaml.dump(master_with_independent))
 
-        api = MockGitHubAPI()  # No release-plan.yaml for SandboxRepo
+        api = MockGitHubAPI()  # No release-plan.yaml for IndependentRepo
         result = collect_all(str(master_file), str(output_file), api=api)
 
-        sandbox_entries = [e for e in result.progress if e.repository == "SandboxRepo"]
-        assert len(sandbox_entries) == 1
-        e = sandbox_entries[0]
+        independent_entries = [e for e in result.progress if e.repository == "IndependentRepo"]
+        assert len(independent_entries) == 1
+        e = independent_entries[0]
         assert e.state == ProgressState.HISTORICAL
         assert e.release_track == "independent"
         assert e.meta_release is None

--- a/workflows/release-progress-tracker/tests/test_milestone_deriver.py
+++ b/workflows/release-progress-tracker/tests/test_milestone_deriver.py
@@ -175,21 +175,21 @@ class TestDeriveCycleReleases:
         assert cr.m1.release_tag == "r2.1"
         assert cr.m3.release_tag == "r2.2"
 
-    def test_sandbox_repo_matched_by_tag_prefix(self):
-        """Repos with meta_release='None (Sandbox)' in releases-master
+    def test_independent_repo_matched_by_tag_prefix(self):
+        """Repos with meta_release='Independent' in releases-master
         should still be matched via tag prefix."""
         releases = [
             {
-                "repository": "NewSandboxRepo",
+                "repository": "IndependentRepo",
                 "release_tag": "r1.1",
                 "release_date": "2026-01-15T00:00:00Z",
-                "meta_release": "None (Sandbox)",
+                "meta_release": "Independent",
                 "release_type": "pre-release-alpha",
-                "apis": [{"api_name": "sandbox-api", "api_version": "0.1.0-alpha.1"}],
+                "apis": [{"api_name": "independent-api", "api_version": "0.1.0-alpha.1"}],
             },
         ]
         cr = derive_cycle_releases(
-            "NewSandboxRepo", "r1.2", "Sync26", releases, ["sandbox-api"],
+            "IndependentRepo", "r1.2", "Sync26", releases, ["independent-api"],
         )
         assert cr.m1.release_tag == "r1.1"
         assert cr.m1.apis[0].api_version == "0.1.0-alpha.1"

--- a/workflows/release-progress-tracker/tests/test_warnings.py
+++ b/workflows/release-progress-tracker/tests/test_warnings.py
@@ -214,8 +214,23 @@ class TestW004MetaReleaseMismatch:
         w004 = [w for w in warnings if w.code == "W004"]
         assert len(w004) == 0
 
-    def test_no_trigger_when_release_meta_is_sandbox(self):
-        """Sandbox repos with 'None (Sandbox)' label should not trigger W004."""
+    def test_no_trigger_when_release_meta_is_independent(self):
+        """Independent releases should not trigger W004."""
+        entry = _make_entry(
+            state=ProgressState.SNAPSHOT_ACTIVE,
+            meta_release="Sync26",
+            target_release_tag="r1.1",
+        )
+        releases = [{
+            "release_tag": "r1.0",
+            "meta_release": "Independent",
+        }]
+        warnings = generate_warnings(entry, releases)
+        w004 = [w for w in warnings if w.code == "W004"]
+        assert len(w004) == 0
+
+    def test_no_trigger_when_release_meta_is_legacy_sandbox(self):
+        """Legacy 'None (Sandbox)' label should not trigger W004 (backward compat)."""
         entry = _make_entry(
             state=ProgressState.SNAPSHOT_ACTIVE,
             meta_release="Sync26",


### PR DESCRIPTION

#### What type of PR is this?

* enhancement

#### What this PR does / why we need it:

Renames the canonical `meta_release` value for releases outside meta-release cycles from `"None (Sandbox)"` to `"Independent"` across the full stack (collector, viewers, progress tracker, campaign code). Schema bumped to 3.1.0.

The term "Sandbox" was misleading — these are independent releases not assigned to a named cycle. The Progress Tracker already used `release_track: "independent"` internally; this aligns the source data label.

**16 files changed across:**
- Collector core (`update-master.js`, `analyze-release.js`, schema, `generate-reports.js`)
- Internal viewer (`internal-template.html`) — filter, counter, row styling, cell display
- Portfolio viewer (`portfolio-template.html`) — constant, CSS classes, display logic
- Progress Tracker (`collect_progress.py`, `warnings.py`, `milestone_deriver.py`)
- Campaign code (`generate-release-plan` src + dist, release-info docs)
- Tests (131 pass, including backward-compat test for legacy value)

**Backward compatibility:** Progress Tracker and campaign code recognize both `"Independent"` and legacy `"None (Sandbox)"` during transition. Generated data files will update on next collector run.

**Scope boundary (unchanged):** `first_release: 'Sandbox'` in enrichment.js (API portfolio lifecycle), `sandbox-api-repository` GitHub topic (repo maturity classification).

#### Which issue(s) this PR fixes:

Fixes #54

#### Special notes for reviewers:

Generated output files (`data/releases-master.yaml`, `reports/*.json`, `viewers/*.html`) are not updated in this PR — they will be regenerated automatically on the next Release Collector workflow run.

#### Additional documentation

Schema changelog entry added in `master-metadata-schema.yaml` (3.1.0).